### PR TITLE
QoL & misc

### DIFF
--- a/build/notifications.js
+++ b/build/notifications.js
@@ -1,0 +1,39 @@
+/* global osdxpNotificationsSettings, jQuery */
+(function( $ ) {
+	'use strict';
+
+	const closet = $( osdxpNotificationsSettings.selectorDrawer );
+	const osdxpNotice = $( osdxpNotificationsSettings.selectorNotice );
+	const inlineClass = 'osdxp-notice-inline';
+	const notices = closet.find( 'div.error,div.notice,div.updated' );
+
+	function reveal() {
+		notices.filter( `.${inlineClass}` ).removeClass( `inline ${inlineClass}` );
+		closet.insertAfter( osdxpNotice ).show();
+		osdxpNotice.remove();
+	}
+
+	function getClass() {
+		if ( closet.find( 'div.error,div.notice-error' ).length ) {
+			return 'notice-error';
+		}
+
+		if ( closet.find( 'div.notice-warning' ).length ) {
+			return 'notice-warning';
+		}
+
+		return 'notice-info';
+	}
+
+	if ( notices.length < osdxpNotificationsSettings.threshold ) {
+		reveal();
+
+		return;
+	}
+
+	notices.not( '.inline' ).addClass( `inline ${inlineClass}` );
+
+	osdxpNotice.addClass( getClass() ).removeClass( 'hide-if-js' );
+
+	osdxpNotice.find( 'button' ).click( reveal );
+})( jQuery );

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "includes/licensing.php",
         "includes/menus.php",
         "includes/modules.php",
-        "includes/utils.php"
+        "includes/utils.php",
+        "includes/notifications.php"
       ],
       "psr-4": {
           "OSDXP_Dashboard\\": "includes/"

--- a/includes/class-osdxp-render-available-modules.php
+++ b/includes/class-osdxp-render-available-modules.php
@@ -90,13 +90,29 @@ class OSDXPAvailableModules
 	 */
 	public function transformData(string $json)
 	{
-		$data = json_decode($json, true);
+		$data = array_change_key_case_recursive(
+			json_decode(
+				$json,
+				true
+			)
+		);
+
+		$data_names = array_column($data['data'], 'name');
 		$partner_data = [];
-		$partner_data = apply_filters('osdxp_get_available_modules', $partner_data);
+		$partner_data = array_change_key_case_recursive(
+			apply_filters(
+				'osdxp_get_available_modules',
+				$partner_data
+			)
+		);
 		foreach ($partner_data as $key => $partner) {
+			if (in_array($partner['name'], $data_names)) {
+				continue;
+			}
 			$data['data'][$key] = $partner;
 		}
-		return array_change_key_case_recursive($data['data']);
+
+		return $data['data'];
 	}
 
 	/**

--- a/includes/core.php
+++ b/includes/core.php
@@ -10,7 +10,8 @@ namespace OSDXP_Dashboard;
 // phpcs:disable
 add_action('init', __NAMESPACE__ . '\\init_dxp_dashboard');
 add_action('login_redirect', __NAMESPACE__ . '\\set_dxp_meta_on_login', 10, 3);
-
+add_action('admin_init', __NAMESPACE__ . '\\limit_admin_color_options', 1);
+add_filter('get_user_option_admin_color', __NAMESPACE__ . '\\force_user_color');
 add_filter('admin_footer_text', __NAMESPACE__ . '\\override_admin_footer_text', 11);
 add_filter('update_footer', __NAMESPACE__ . '\\override_update_footer', 11);
 // phpcs:enable
@@ -241,4 +242,37 @@ function override_update_footer($text)
 	}
 
 	return $dxp_text . '<br>' . $wp_text;
+}
+
+/**
+ * Method to remove admin color theme picker if on osDXP.
+ *
+ * @return void
+ */
+function limit_admin_color_options()
+{
+	if (!is_dxp_dashboard()) {
+		return;
+	}
+	global $_wp_admin_css_colors;
+
+	$fresh_color_data = $_wp_admin_css_colors['fresh'];
+	$fresh_color_data->icon_colors = [
+		'base' => '#fff',
+		'focus' => '#3C15B4',
+		'current' => '#3C15B4',
+	];
+
+	$_wp_admin_css_colors = array( 'fresh' => $fresh_color_data );
+}
+
+/**
+ * Method to force color theme if on osDXP.
+ *
+ * @param  $color string of color theme
+ * @return string
+ */
+function force_user_color($color)
+{
+	return is_dxp_dashboard() ? 'fresh' : $color;
 }

--- a/includes/dependencies/wordpress/class-osdxp-modules-list-table.php
+++ b/includes/dependencies/wordpress/class-osdxp-modules-list-table.php
@@ -899,7 +899,8 @@ class OSDXP_Modules_List_Table extends \WP_List_Table
 					}
 
 					echo '<div class="module-actions">';
-					echo '<a target="_blank" class="button-primary" href="' . $module_data['AuthorURI'] . '">' . esc_html__('Manage License', 'osdxp-dashboard') . '</a>';
+					$button_text = apply_filters('osdxp_manage_button_module_' . $plugin_slug, 'Manage License');
+					echo '<a target="_blank" class="button-primary" href="' . $module_data['AuthorURI'] . '">' . esc_html__($button_text, 'osdxp-dashboard') . '</a>';
 					/**
 					 * Filters the array of row meta for each module in the Modules list table.
 					 *

--- a/includes/menus.php
+++ b/includes/menus.php
@@ -242,16 +242,29 @@ function dxp_admin_add_menu_items(bool $network = false)
  */
 function dxp_accepted_top_pages()
 {
+	// dashboard, pages and posts
 	$menu_list = [
 		'index.php',
 		'edit.php?post_type=page',
 		'edit.php'
 	];
+
+	// cpts
 	$cpts = get_post_types(['_builtin'  => false], 'names');
 	$cpts = apply_filters('osdxp_filter_cpts', $cpts);
 
 	foreach ($cpts as $cpt) {
 		$menu_list[] = 'edit.php?post_type=' . $cpt;
+	}
+
+	// non-dashboard osDXP top-level pages
+	$custom_pages = [];
+	$custom_pages = apply_filters('osdxp_add_module_settings_page', $custom_pages);
+	foreach ($custom_pages as $custom_page) {
+		if (!isset($custom_page['type']) || OSDXP_DASHBOARD_MENU_TYPE_MENU !== $custom_page['type']) {
+			continue;
+		}
+		$menu_list[] = $custom_page['menu_slug'];
 	}
 
 	array_push(

--- a/includes/modules.php
+++ b/includes/modules.php
@@ -24,13 +24,13 @@ function filter_plugins($plugins)
 	}
 
 	$osdxp_modules = get_osdxp_available_modules();
-	$osdxp_modules_name = array_column($osdxp_modules, 'name');
+	$module_names = array_column($osdxp_modules, 'name');
 
 	foreach ($plugins as $key => $plugin_data) {
-		$is_osdxp_module = array_search($plugin_data['Name'], $osdxp_modules_name);
-
-		// An OSDXP module.
-		if (false !== $is_osdxp_module) {
+		$module_key = array_search($plugin_data['Name'], $module_names);
+		$module_name = $module_key ? $module_names[$module_key] : false;
+		// An osDXP module but not osDXP dashboard.
+		if (false !== $module_name && 'Open Source DXP Dashboard' !== $module_name) {
 			unset($plugins[$key]);
 		}
 	}

--- a/includes/modules.php
+++ b/includes/modules.php
@@ -28,7 +28,7 @@ function filter_plugins($plugins)
 
 	foreach ($plugins as $key => $plugin_data) {
 		$module_key = array_search($plugin_data['Name'], $module_names);
-		$module_name = $module_key ? $module_names[$module_key] : false;
+		$module_name = (false !== $module_key) ? $module_names[$module_key] : false;
 		// An osDXP module but not osDXP dashboard.
 		if (false !== $module_name && 'Open Source DXP Dashboard' !== $module_name) {
 			unset($plugins[$key]);

--- a/includes/notifications.php
+++ b/includes/notifications.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * File containing the notification hiding logic.
+ *
+ * @package osdxp-dashboard
+ */
+
+namespace OSDXP_Dashboard;
+
+// phpcs:disable
+if (! is_admin()) {
+	return;
+}
+// phpcs:enable
+
+// Output grouping notification and load required js
+function notifications()
+{
+
+	if (is_network_admin()) {
+		$action = 'network_admin_notices';
+	} elseif (is_user_admin()) {
+		$action = 'user_admin_notices';
+	} else {
+		$action = 'admin_notices';
+	}
+	add_action($action, function () {
+
+		ob_start();
+	}, (int) ( PHP_INT_MAX + 1 ));
+
+	add_action('all_admin_notices', function () {
+
+		$contents = trim(ob_get_clean());
+		if ('' === $contents) {
+			return;
+		}
+
+		$notice_id = 'osdxp-notifications';
+
+		$drawer_id = 'osdxp-drawer';
+		?>
+		<div id="<?php echo esc_attr($notice_id); ?>" class="notice hide-if-js">
+			<p>
+				<?php esc_html_e('Administrative Notices have been minimized.', 'osdxp-dashboard'); ?>
+				<button class="button"><?php esc_html_e('Reveal', 'osdxp-dashboard'); ?></button>
+			</p>
+		</div>
+		<div id="<?php echo esc_attr($drawer_id); ?>" class="hide-if-js">
+			<?php echo $contents; // phpcs:ignore?>
+		</div>
+		<?php
+		wp_enqueue_script(
+			'osdxp-notifications',
+			OSDXP_DASHBOARD_URL . 'build/notifications.js',
+			[ 'jquery' ],
+			filemtime(OSDXP_DASHBOARD_DIR . 'build/notifications.js')
+		);
+
+		/**
+		 * Filters the minimum number of admin notices required to take action.
+		 *
+		 * @param int $threshold Required minimum number of admin notices.
+		 */
+		$threshold = (int) apply_filters('osdxp_notifications_threshold', 1);
+		wp_localize_script('osdxp-notifications', 'osdxpNotificationsSettings', [
+			'selectorDrawer' => "#{$drawer_id}",
+			'selectorNotice'  => "#{$notice_id}",
+			'threshold'      => max(1, $threshold),
+		]);
+	}, PHP_INT_MAX);
+}
+// phpcs:disable
+add_action('plugins_loaded', __NAMESPACE__ . '\\notifications');
+// phpcs:enable

--- a/templates/modules-list-available.php
+++ b/templates/modules-list-available.php
@@ -25,7 +25,18 @@ if (isset($_GET["refresh"]) && $_GET['refresh']) { // phpcs:ignore
 				<div class="am-grid-col-container">
 					<div class="am-info am-grid-col-container">
 						<div>
-							<?php if (!empty($module_info['logo'])) : ?>
+							<?php
+							$valid_logo = !empty($module_info['logo']);
+							$valid_logo = $valid_logo ? filter_var($module_info['logo'], FILTER_VALIDATE_URL) : false;
+							$valid_logo = $valid_logo ? pathinfo($valid_logo, PATHINFO_EXTENSION) : false;
+							$extensions = [
+								'png',
+								'svg',
+								'jpeg',
+								'jpg',
+							];
+							?>
+							<?php if (in_array($valid_logo, $extensions)) : ?>
 								<img src="<?php echo esc_url($module_info['logo']); ?>">
 							<?php else : ?>
 								<img src="<?php echo esc_url(OSDXP_DASHBOARD_PLACEHOLDER_IMAGE_URL); ?>">

--- a/templates/modules-list-available.php
+++ b/templates/modules-list-available.php
@@ -1,10 +1,12 @@
 <?php
 namespace OSDXP_Dashboard;
+
 if (isset($_GET["refresh"]) && $_GET['refresh']) { // phpcs:ignore
 	delete_transient(OSDXP_DASHBOARD_AVAILABLE_MODULES_TRANSIENT);
+    $jsonData = $this->getModulesData();
+    $data =  $this->transformData($jsonData);
 }
 ?>
-
 
 <h1>
 	<?php esc_html_e('Available Modules', 'osdxp-dashboard');?>

--- a/vendor/composer/autoload_files.php
+++ b/vendor/composer/autoload_files.php
@@ -16,4 +16,5 @@ return array(
     'c2657873473474d6490127c4a7e6cdd1' => $baseDir . '/includes/menus.php',
     '34d3aba17674de223ab58b6807ffaf14' => $baseDir . '/includes/modules.php',
     'acc9f2579fece20728bfeed1a4d7ebce' => $baseDir . '/includes/utils.php',
+    '5dd59f8beed6a6251f319543198aec7e' => $baseDir . '/includes/notifications.php',
 );

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -17,6 +17,7 @@ class ComposerStaticInit77c90c4949a4c0fcfed8baebc8bc36c3
         'c2657873473474d6490127c4a7e6cdd1' => __DIR__ . '/../..' . '/includes/menus.php',
         '34d3aba17674de223ab58b6807ffaf14' => __DIR__ . '/../..' . '/includes/modules.php',
         'acc9f2579fece20728bfeed1a4d7ebce' => __DIR__ . '/../..' . '/includes/utils.php',
+        '5dd59f8beed6a6251f319543198aec7e' => __DIR__ . '/../..' . '/includes/notifications.php',
     );
 
     public static $prefixLengthsPsr4 = array (


### PR DESCRIPTION
 - add filter for the `manage license` button in installed modules page
 - validates logo url from available modules data
 - adds notification drawer
 - custom top-level menu pages are correctly ordered now
 - available modules is now correctly refreshed on first reload after button press
 - modules are now correctly being displayed only once if both added through the filter & present in available modules data
 - if the user is using osDXP, remove admin color theme picker and force osDXP-specific colours 