### PR TITLE
removed word Legacy from admin bar menu

### DIFF
--- a/assets/sass/admin-bar.scss
+++ b/assets/sass/admin-bar.scss
@@ -339,7 +339,7 @@
 		}
 	}
 
-	/* When hovering over the Switch to DXP/Back to Legacy WordPress icon... */
+	/* When hovering over the Switch to DXP/Back to WordPress icon... */
 	&:active,
 	&:focus,
 	&:hover {

--- a/build/admin-bar.css
+++ b/build/admin-bar.css
@@ -260,7 +260,7 @@
     width: 36px; }
 
 #wp-admin-bar-switch-to-dxp {
-  /* When hovering over the Switch to DXP/Back to Legacy WordPress icon... */ }
+  /* When hovering over the Switch to DXP/Back to WordPress icon... */ }
   #wp-admin-bar-switch-to-dxp a {
     overflow: hidden; }
     #wp-admin-bar-switch-to-dxp a > div {

--- a/build/style-admin.css
+++ b/build/style-admin.css
@@ -399,7 +399,7 @@
     width: 36px; }
 
 #wp-admin-bar-switch-to-dxp {
-  /* When hovering over the Switch to DXP/Back to Legacy WordPress icon... */ }
+  /* When hovering over the Switch to DXP/Back to WordPress icon... */ }
   #wp-admin-bar-switch-to-dxp a {
     overflow: hidden; }
     #wp-admin-bar-switch-to-dxp a > div {

--- a/includes/menus.php
+++ b/includes/menus.php
@@ -88,7 +88,7 @@ function add_switch_to_dxp_button_to_admin_bar_menu($wp_admin_bar)
 					'id'    => 'switch-to-dxp',
 					'title' => sprintf(
 						'<div>%s</div>',
-						__('<div>Return to<br>Legacy WordPress</div>', 'osdxp-dashboard')
+						__('<div>Return to<br> WordPress</div>', 'osdxp-dashboard')
 					),
 					'href'  => '/wp-admin/?dxp=off', // return to wp-admin dashboard
 				]

--- a/languages/en_US.po
+++ b/languages/en_US.po
@@ -847,7 +847,7 @@ msgid "Latest Version Installed"
 msgstr ""
 
 #: includes/menus.php:85
-msgid "<div>Return to<br>Legacy WordPress</div>"
+msgid "<div>Return to<br> WordPress</div>"
 msgstr ""
 
 #: includes/menus.php:95


### PR DESCRIPTION
Removed "Legacy" from "Return to Legacy WordPress" language in the admin-bar menu. It now reads, "Return to WordPress"