### PR TITLE
1.0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require": {
-    "yahnis-elsts/plugin-update-checker": "~4.7.0"
+    "yahnis-elsts/plugin-update-checker": "~4.8.0"
   },
   "autoload": {
       "files" : [

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6a421205682c263dc7ef3ba780b3066",
+    "content-hash": "4e32a9d9bd590e54bb36c1a0c21d469b",
     "packages": [
         {
             "name": "yahnis-elsts/plugin-update-checker",
-            "version": "v4.7",
+            "version": "v4.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/YahnisElsts/plugin-update-checker.git",
-                "reference": "6da68b119277a400fad0ca6ec54f223b10bd8230"
+                "reference": "908249c92e81c46cb66e4d81632c5e917dc879ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/YahnisElsts/plugin-update-checker/zipball/6da68b119277a400fad0ca6ec54f223b10bd8230",
-                "reference": "6da68b119277a400fad0ca6ec54f223b10bd8230",
+                "url": "https://api.github.com/repos/YahnisElsts/plugin-update-checker/zipball/908249c92e81c46cb66e4d81632c5e917dc879ae",
+                "reference": "908249c92e81c46cb66e4d81632c5e917dc879ae",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,7 @@
             "type": "library",
             "autoload": {
                 "files": [
-                    "plugin-update-checker.php"
+                    "load-v4p8.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -49,7 +49,7 @@
                 "theme updates",
                 "wordpress"
             ],
-            "time": "2019-07-05T18:39:53+00:00"
+            "time": "2019-10-08T12:15:30+00:00"
         }
     ],
     "packages-dev": [],

--- a/includes/dependencies/plugin-update-checker/class-osdxp-module-update-checker-ui.php
+++ b/includes/dependencies/plugin-update-checker/class-osdxp-module-update-checker-ui.php
@@ -340,6 +340,7 @@ class OsdxpModuleUpdateCheckerUi
 		remove_action('admin_init', array($this, 'onAdminInit'));
 		remove_filter('plugin_row_meta', array($this, 'addViewDetailsLink'), 10);
 		remove_filter('plugin_row_meta', array($this, 'addCheckForUpdatesLink'), 10);
+		remove_filter('osdxp_module_column_status', array($this, 'addCheckForUpdatesButton'), 10, 2);
 		remove_action('all_admin_notices', array($this, 'displayManualCheckResult'));
 	}
 }

--- a/includes/dependencies/plugin-update-checker/class-osdxp-module-update-checker-ui.php
+++ b/includes/dependencies/plugin-update-checker/class-osdxp-module-update-checker-ui.php
@@ -15,9 +15,9 @@ class OsdxpModuleUpdateCheckerUi
 	private $updateChecker;
 	private $manualCheckErrorTransient = '';
 
-		/**
-		 * @param OsdxpModuleUpdateChecker $updateChecker
-		 */
+	/**
+	 * @param OsdxpModuleUpdateChecker $updateChecker
+	 */
 	public function __construct($updateChecker)
 	{
 		$this->updateChecker = $updateChecker;
@@ -38,28 +38,28 @@ class OsdxpModuleUpdateCheckerUi
 		}
 	}
 
-		/**
-		 * Add a "View Details" link to the module row in the "Modules" page. By default,
-		 * the new link will appear before the "Visit module site" link (if present).
-		 *
-		 * You can change the link text by using the "puc_view_details_link-$slug" filter.
-		 * Returning an empty string from the filter will disable the link.
-		 *
-		 * You can change the position of the link using the
-		 * "puc_view_details_link_position-$slug" filter.
-		 * Returning 'before' or 'after' will place the link immediately before/after
-		 * the "Visit module site" link.
-		 * Returning 'append' places the link after any existing links at the time of the hook.
-		 * Returning 'replace' replaces the "Visit module site" link.
-		 * Returning anything else disables the link when there is a "Visit module site" link.
-		 *
-		 * If there is no "Visit module site" link 'append' is always used!
-		 *
-		 * @param array $pluginMeta Array of meta links.
-		 * @param string $pluginFile
-		 * @param array $pluginData Array of module header data.
-		 * @return array
-		 */
+	/**
+	 * Add a "View Details" link to the module row in the "Modules" page. By default,
+	 * the new link will appear before the "Visit module site" link (if present).
+	 *
+	 * You can change the link text by using the "puc_view_details_link-$slug" filter.
+	 * Returning an empty string from the filter will disable the link.
+	 *
+	 * You can change the position of the link using the
+	 * "puc_view_details_link_position-$slug" filter.
+	 * Returning 'before' or 'after' will place the link immediately before/after
+	 * the "Visit module site" link.
+	 * Returning 'append' places the link after any existing links at the time of the hook.
+	 * Returning 'replace' replaces the "Visit module site" link.
+	 * Returning anything else disables the link when there is a "Visit module site" link.
+	 *
+	 * If there is no "Visit module site" link 'append' is always used!
+	 *
+	 * @param array $pluginMeta Array of meta links.
+	 * @param string $pluginFile
+	 * @param array $pluginData Array of module header data.
+	 * @return array
+	 */
 	public function addViewDetailsLink($pluginMeta, $pluginFile, $pluginData = array())
 	{
 		if ($this->isMyPluginFile($pluginFile) && !isset($pluginData['slug'])) {
@@ -67,7 +67,7 @@ class OsdxpModuleUpdateCheckerUi
 			if (!empty($linkText)) {
 				$viewDetailsLinkPosition = 'append';
 
-				//Find the "Visit plugin site" link (if present).
+			//Find the "Visit plugin site" link (if present).
 				$visitPluginSiteLinkIndex = count($pluginMeta) - 1;
 				if ($pluginData['PluginURI']) {
 					$escapedPluginUri = esc_url($pluginData['PluginURI']);
@@ -116,18 +116,18 @@ class OsdxpModuleUpdateCheckerUi
 		return $pluginMeta;
 	}
 
-		/**
-		 * Add a "Check for updates" link to the module row in the "Modules" page. By default,
-		 * the new link will appear after the "Visit module site" link if present, otherwise
-		 * after the "View module details" link.
-		 *
-		 * You can change the link text by using the "puc_manual_check_link-$slug" filter.
-		 * Returning an empty string from the filter will disable the link.
-		 *
-		 * @param array $pluginMeta Array of meta links.
-		 * @param string $pluginFile
-		 * @return array
-		 */
+	/**
+	 * Add a "Check for updates" link to the module row in the "Modules" page. By default,
+	 * the new link will appear after the "Visit module site" link if present, otherwise
+	 * after the "View module details" link.
+	 *
+	 * You can change the link text by using the "puc_manual_check_link-$slug" filter.
+	 * Returning an empty string from the filter will disable the link.
+	 *
+	 * @param array $pluginMeta Array of meta links.
+	 * @param string $pluginFile
+	 * @return array
+	 */
 	public function addCheckForUpdatesLink($pluginMeta, $pluginFile)
 	{
 		if ($this->isMyPluginFile($pluginFile)) {
@@ -183,32 +183,32 @@ class OsdxpModuleUpdateCheckerUi
 	protected function isMyPluginFile($pluginFile)
 	{
 		return ($pluginFile == $this->updateChecker->pluginFile)
-			|| (!empty($this->updateChecker->muPluginFile) && ($pluginFile == $this->updateChecker->muPluginFile));
+		|| (!empty($this->updateChecker->muPluginFile) && ($pluginFile == $this->updateChecker->muPluginFile));
 	}
 
-		/**
-		 * Check for updates when the user clicks the "Check for updates" link.
-		 *
-		 * @see self::addCheckForUpdatesLink()
-		 *
-		 * @return void
-		 */
+	/**
+	 * Check for updates when the user clicks the "Check for updates" link.
+	 *
+	 * @see self::addCheckForUpdatesLink()
+	 *
+	 * @return void
+	 */
 	public function handleManualCheck()
 	{
 		$shouldCheck =
-			isset($_GET['puc_check_for_updates'], $_GET['puc_slug'])
-			&& $_GET['puc_slug'] == $this->updateChecker->slug
-			&& check_admin_referer('puc_check_for_updates');
+		isset($_GET['puc_check_for_updates'], $_GET['puc_slug'])
+		&& $_GET['puc_slug'] == $this->updateChecker->slug
+		&& check_admin_referer('puc_check_for_updates');
 
 		if ($shouldCheck) {
 			$update = $this->updateChecker->checkForUpdates();
 			$status = ($update === null) ? 'no_update' : 'update_available';
 
 			if (($update === null) && !empty($this->lastRequestApiErrors)) {
-				//Some errors are not critical. For example, if PUC tries to retrieve the readme.txt
-				//file from GitHub and gets a 404, that's an API error, but it doesn't prevent updates
-				//from working. Maybe the module simply doesn't have a readme.
-				//Let's only show important errors.
+			//Some errors are not critical. For example, if PUC tries to retrieve the readme.txt
+			//file from GitHub and gets a 404, that's an API error, but it doesn't prevent updates
+			//from working. Maybe the module simply doesn't have a readme.
+			//Let's only show important errors.
 				$foundCriticalErrors = false;
 				$questionableErrorCodes = array(
 					'puc-github-http-error',
@@ -242,22 +242,22 @@ class OsdxpModuleUpdateCheckerUi
 		}
 	}
 
-		/**
-		 * Display the results of a manual update check.
-		 *
-		 * @see self::handleManualCheck()
-		 *
-		 * You can change the result message by using the "puc_manual_check_message-$slug" filter.
-		 */
+	/**
+	 * Display the results of a manual update check.
+	 *
+	 * @see self::handleManualCheck()
+	 *
+	 * You can change the result message by using the "puc_manual_check_message-$slug" filter.
+	 */
 	public function displayManualCheckResult()
 	{
-		// phpcs:disable
+	// phpcs:disable
 		if (isset($_GET['puc_update_check_result'], $_GET['puc_slug'])&& ($_GET['puc_slug'] == $this->updateChecker->slug)) {
 			$status = strval($_GET['puc_update_check_result']);
 			$title = $this->updateChecker->getInstalledPackage()->getPluginTitle();
 			$noticeClass = 'updated notice-success';
 			$details = '';
-		// phpcs:enable
+	// phpcs:enable
 			if ($status == 'no_update') {
 				$message = sprintf(
 					_x('The %s module is up to date.', 'the plugin title', 'plugin-update-checker'),
@@ -288,23 +288,23 @@ class OsdxpModuleUpdateCheckerUi
 				);
 				$noticeClass = 'error notice-error';
 			}
-			// phpcs:disable
+		// phpcs:disable
 			printf(
 				'<div class="notice %s is-dismissible"><p>%s</p>%s</div>',
 				$noticeClass,
 				apply_filters($this->updateChecker->getUniqueName('manual_check_message'), $message, $status),
 				$details
 			);
-			// phpcs:enable
+		// phpcs:enable
 		}
 	}
 
-		/**
-		 * Format the list of errors that were thrown during an update check.
-		 *
-		 * @param array $errors
-		 * @return string
-		 */
+	/**
+	 * Format the list of errors that were thrown during an update check.
+	 *
+	 * @param array $errors
+	 * @return string
+	 */
 	protected function formatManualCheckErrors($errors)
 	{
 		if (empty($errors)) {

--- a/includes/dependencies/plugin-update-checker/class-osdxp-module-update-checker-ui.php
+++ b/includes/dependencies/plugin-update-checker/class-osdxp-module-update-checker-ui.php
@@ -3,7 +3,7 @@
  * Module Update Checker UI
  * This adds extra links to module table view to check for updates & extra
  *
- * @see   Puc_v4p7_Plugin_Ui
+ * @see   Puc_v4p8_Plugin_Ui
  */
 namespace OSDXP_Dashboard;
 

--- a/includes/dependencies/plugin-update-checker/class-osdxp-module-update-checker.php
+++ b/includes/dependencies/plugin-update-checker/class-osdxp-module-update-checker.php
@@ -15,24 +15,24 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p8_UpdateChecker
 	public $pluginFile = '';  //Module filename relative to the modules directory.
 	public $muPluginFile = ''; //For MU modules, the module filename relative to the mu-plugins directory.
 
-		/**
-		 * @var Puc_v4p8_Plugin_Package
-		 */
+	/**
+	 * @var Puc_v4p8_Plugin_Package
+	 */
 	protected $package;
 
 	private $extraUi = null;
-		// phpcs:disable
-		/**
-		 * Class constructor.
-		 *
-		 * @param string $metadataUrl The URL of the module's metadata file.
-		 * @param string $pluginFile Fully qualified path to the main module file.
-		 * @param string $slug The module's 'slug'. If not specified, the filename part of $pluginFile sans '.php' will be used as the slug.
-		 * @param integer $checkPeriod How often to check for updates (in hours). Defaults to checking every 12 hours. Set to 0 to disable automatic update checks.
-		 * @param string $optionName Where to store book-keeping info about update checks. Defaults to 'external_updates-$slug'.
-		 * @param string $muPluginFile Optional. The module filename relative to the mu-plugins directory.
-		 */
-		// phpcs:enable
+	// phpcs:disable
+	/**
+	 * Class constructor.
+	 *
+	 * @param string $metadataUrl The URL of the module's metadata file.
+	 * @param string $pluginFile Fully qualified path to the main module file.
+	 * @param string $slug The module's 'slug'. If not specified, the filename part of $pluginFile sans '.php' will be used as the slug.
+	 * @param integer $checkPeriod How often to check for updates (in hours). Defaults to checking every 12 hours. Set to 0 to disable automatic update checks.
+	 * @param string $optionName Where to store book-keeping info about update checks. Defaults to 'external_updates-$slug'.
+	 * @param string $muPluginFile Optional. The module filename relative to the mu-plugins directory.
+	 */
+	// phpcs:enable
 	public function __construct(
 		$metadataUrl,
 		$pluginFile,
@@ -45,13 +45,13 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p8_UpdateChecker
 		$this->pluginFile = plugin_basename($this->pluginAbsolutePath);
 		$this->muPluginFile = $muPluginFile;
 
-		//If no slug is specified, use the name of the main module file as the slug.
-		//For example, 'my-cool-module/cool-module.php' becomes 'cool-module'.
+	//If no slug is specified, use the name of the main module file as the slug.
+	//For example, 'my-cool-module/cool-module.php' becomes 'cool-module'.
 		if (empty($slug)) {
 			$slug = basename($this->pluginFile, '.php');
 		}
 
-		//Module slugs must be unique.
+	//Module slugs must be unique.
 		$slugCheckFilter = 'puc_is_slug_in_use-' . $slug;
 		$slugUsedBy = apply_filters($slugCheckFilter, false);
 		if ($slugUsedBy) {
@@ -63,14 +63,14 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p8_UpdateChecker
 		}
 		add_filter($slugCheckFilter, array($this, 'getAbsolutePath'));
 
-		//Backwards compatibility: If the module is a mu-plugin but no $muPluginFile is specified, assume
-		//it's the same as $pluginFile given that it's not in a subdirectory (WP only looks in the base dir).
+	//Backwards compatibility: If the module is a mu-plugin but no $muPluginFile is specified, assume
+	//it's the same as $pluginFile given that it's not in a subdirectory (WP only looks in the base dir).
 		if ((strpbrk($this->pluginFile, '/\\') === false) && $this->isUnknownMuPlugin()) {
 			$this->muPluginFile = $this->pluginFile;
 		}
 
-		//To prevent a crash during module uninstallation, remove updater hooks when the user removes the module.
-		//Details: https://github.com/YahnisElsts/plugin-update-checker/issues/138#issuecomment-335590964
+	//To prevent a crash during module uninstallation, remove updater hooks when the user removes the module.
+	//Details: https://github.com/YahnisElsts/plugin-update-checker/issues/138#issuecomment-335590964
 		add_action('uninstall_' . $this->pluginFile, array($this, 'removeHooks'));
 
 		parent::__construct($metadataUrl, dirname($this->pluginFile), $slug, $checkPeriod, $optionName);
@@ -78,12 +78,12 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p8_UpdateChecker
 		$this->extraUi = new OsdxpModuleUpdateCheckerUi($this);
 	}
 
-		/**
-		 * Create an instance of the scheduler.
-		 *
-		 * @param int $checkPeriod
-		 * @return Puc_v4p8_Scheduler
-		 */
+	/**
+	 * Create an instance of the scheduler.
+	 *
+	 * @param int $checkPeriod
+	 * @return Puc_v4p8_Scheduler
+	 */
 	protected function createScheduler($checkPeriod)
 	{
 		$scheduler = new \Puc_v4p8_Scheduler($this, $checkPeriod, array('load-plugins.php'));
@@ -91,34 +91,34 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p8_UpdateChecker
 		return $scheduler;
 	}
 
-		/**
-		 * Install the hooks required to run periodic update checks and inject update info
-		 * into WP data structures.
-		 *
-		 * @return void
-		 */
+	/**
+	 * Install the hooks required to run periodic update checks and inject update info
+	 * into WP data structures.
+	 *
+	 * @return void
+	 */
 	protected function installHooks()
 	{
-		//Override requests for plugin information
+	//Override requests for plugin information
 		add_filter('plugins_api', array($this, 'injectInfo'), 20, 3);
 
 		parent::installHooks();
 	}
 
-		/**
-		 * Remove update checker hooks.
-		 *
-		 * The intent is to prevent a fatal error that can happen if the module has an uninstall
-		 * hook. During uninstallation, WP includes the main module file (which creates a PUC instance),
-		 * the uninstall hook runs, WP deletes the module files and then updates some transients.
-		 * If PUC hooks are still around at this time, they could throw an error while trying to
-		 * autoload classes from files that no longer exist.
-		 *
-		 * The "site_transient_{$transient}" filter is the main problem here, but let's also remove
-		 * most other PUC hooks to be safe.
-		 *
-		 * @internal
-		 */
+	/**
+	 * Remove update checker hooks.
+	 *
+	 * The intent is to prevent a fatal error that can happen if the module has an uninstall
+	 * hook. During uninstallation, WP includes the main module file (which creates a PUC instance),
+	 * the uninstall hook runs, WP deletes the module files and then updates some transients.
+	 * If PUC hooks are still around at this time, they could throw an error while trying to
+	 * autoload classes from files that no longer exist.
+	 *
+	 * The "site_transient_{$transient}" filter is the main problem here, but let's also remove
+	 * most other PUC hooks to be safe.
+	 *
+	 * @internal
+	 */
 	public function removeHooks()
 	{
 		parent::removeHooks();
@@ -128,14 +128,14 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p8_UpdateChecker
 		remove_filter('plugins_api', array($this, 'injectInfo'), 20);
 	}
 
-		/**
-		 * Retrieve module info from the configured API endpoint.
-		 *
-		 * @uses wp_remote_get()
-		 *
-		 * @param array $queryArgs Additional query arguments to append to the request. Optional.
-		 * @return Puc_v4p8_Plugin_Info
-		 */
+	/**
+	 * Retrieve module info from the configured API endpoint.
+	 *
+	 * @uses wp_remote_get()
+	 *
+	 * @param array $queryArgs Additional query arguments to append to the request. Optional.
+	 * @return Puc_v4p8_Plugin_Info
+	 */
 	public function requestInfo($queryArgs = array())
 	{
 		list($pluginInfo, $result) = $this->requestMetadata('Puc_v4p8_Plugin_Info', 'request_info', $queryArgs);
@@ -150,17 +150,17 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p8_UpdateChecker
 		return $pluginInfo;
 	}
 
-		/**
-		 * Retrieve the latest update (if any) from the configured API endpoint.
-		 *
-		 * @uses PluginUpdateChecker::requestInfo()
-		 *
-		 * @return Puc_v4p8_Update|null An instance of Plugin_Update, or NULL when no updates are available.
-		 */
+	/**
+	 * Retrieve the latest update (if any) from the configured API endpoint.
+	 *
+	 * @uses PluginUpdateChecker::requestInfo()
+	 *
+	 * @return Puc_v4p8_Update|null An instance of Plugin_Update, or NULL when no updates are available.
+	 */
 	public function requestUpdate()
 	{
-		//For the sake of simplicity, this function just calls requestInfo()
-		//and transforms the result accordingly.
+	//For the sake of simplicity, this function just calls requestInfo()
+	//and transforms the result accordingly.
 		$pluginInfo = $this->requestInfo(array('checking_for_updates' => '1'));
 		if ($pluginInfo === null) {
 			return null;
@@ -172,22 +172,22 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p8_UpdateChecker
 		return $update;
 	}
 
-		/**
-		 * Intercept plugins_api() calls that request information about our module and
-		 * use the configured API endpoint to satisfy them.
-		 *
-		 * @see plugins_api()
-		 *
-		 * @param mixed $result
-		 * @param string $action
-		 * @param array|object $args
-		 * @return mixed
-		 */
+	/**
+	 * Intercept plugins_api() calls that request information about our module and
+	 * use the configured API endpoint to satisfy them.
+	 *
+	 * @see plugins_api()
+	 *
+	 * @param mixed $result
+	 * @param string $action
+	 * @param array|object $args
+	 * @return mixed
+	 */
 	public function injectInfo($result, $action = null, $args = null)
 	{
 		$relevant = ($action == 'plugin_information') && isset($args->slug) && (
-				($args->slug == $this->slug) || ($args->slug == dirname($this->pluginFile))
-			);
+			($args->slug == $this->slug) || ($args->slug == dirname($this->pluginFile))
+		);
 		if (!$relevant) {
 			return $result;
 		}
@@ -203,30 +203,30 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p8_UpdateChecker
 
 	protected function shouldShowUpdates()
 	{
-		//No update notifications for mu-plugins unless explicitly enabled. The MU module file
-		//is usually different from the main module file so the update wouldn't show up properly anyway.
+	//No update notifications for mu-plugins unless explicitly enabled. The MU module file
+	//is usually different from the main module file so the update wouldn't show up properly anyway.
 		return !$this->isUnknownMuPlugin();
 	}
 
-		/**
-		 * @param stdClass|null $updates
-		 * @param stdClass $updateToAdd
-		 * @return stdClass
-		 */
+	/**
+	 * @param stdClass|null $updates
+	 * @param stdClass $updateToAdd
+	 * @return stdClass
+	 */
 	protected function addUpdateToList($updates, $updateToAdd)
 	{
 		if ($this->package->isMuPlugin()) {
-			//WP does not support automatic update installation for mu-plugins, but we can
-			//still display a notice.
+		//WP does not support automatic update installation for mu-plugins, but we can
+		//still display a notice.
 			$updateToAdd->package = null;
 		}
 		return parent::addUpdateToList($updates, $updateToAdd);
 	}
 
-		/**
-		 * @param stdClass|null $updates
-		 * @return stdClass|null
-		 */
+	/**
+	 * @param stdClass|null $updates
+	 * @return stdClass|null
+	 */
 	protected function removeUpdateFromList($updates)
 	{
 		$updates = parent::removeUpdateFromList($updates);
@@ -236,12 +236,12 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p8_UpdateChecker
 		return $updates;
 	}
 
-		/**
-		 * For modules, the update array is indexed by the modules filename relative to the "modules"
-		 * directory. Example: "module-name/module.php".
-		 *
-		 * @return string
-		 */
+	/**
+	 * For modules, the update array is indexed by the modules filename relative to the "modules"
+	 * directory. Example: "module-name/module.php".
+	 *
+	 * @return string
+	 */
 	protected function getUpdateListKey()
 	{
 		if ($this->package->isMuPlugin()) {
@@ -250,40 +250,40 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p8_UpdateChecker
 		return $this->pluginFile;
 	}
 
-		/**
-		 * Alias for isBeingUpgraded().
-		 *
-		 * @deprecated
-		 * @param WP_Upgrader|null $upgrader The upgrader that's performing the current update.
-		 * @return bool
-		 */
+	/**
+	 * Alias for isBeingUpgraded().
+	 *
+	 * @deprecated
+	 * @param WP_Upgrader|null $upgrader The upgrader that's performing the current update.
+	 * @return bool
+	 */
 	public function isPluginBeingUpgraded($upgrader = null)
 	{
 		return $this->isBeingUpgraded($upgrader);
 	}
 
-		/**
-		 * Is there an update being installed for this module, right now?
-		 *
-		 * @param WP_Upgrader|null $upgrader
-		 * @return bool
-		 */
+	/**
+	 * Is there an update being installed for this module, right now?
+	 *
+	 * @param WP_Upgrader|null $upgrader
+	 * @return bool
+	 */
 	public function isBeingUpgraded($upgrader = null)
 	{
 		return $this->upgraderStatus->isPluginBeingUpgraded($this->pluginFile, $upgrader);
 	}
 
-		/**
-		 * Get the details of the currently available update, if any.
-		 *
-		 * If no updates are available, or if the last known update version is below or equal
-		 * to the currently installed version, this method will return NULL.
-		 *
-		 * Uses cached update data. To retrieve update information straight from
-		 * the metadata URL, call requestUpdate() instead.
-		 *
-		 * @return Puc_v4p8_Plugin_Update|null
-		 */
+	/**
+	 * Get the details of the currently available update, if any.
+	 *
+	 * If no updates are available, or if the last known update version is below or equal
+	 * to the currently installed version, this method will return NULL.
+	 *
+	 * Uses cached update data. To retrieve update information straight from
+	 * the metadata URL, call requestUpdate() instead.
+	 *
+	 * @return Puc_v4p8_Plugin_Update|null
+	 */
 	public function getUpdate()
 	{
 		$update = parent::getUpdate();
@@ -294,107 +294,107 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p8_UpdateChecker
 		return $update;
 	}
 
-		/**
-		 * Get the translated module title.
-		 *
-		 * @deprecated
-		 * @return string
-		 */
+	/**
+	 * Get the translated module title.
+	 *
+	 * @deprecated
+	 * @return string
+	 */
 	public function getPluginTitle()
 	{
 		return $this->package->getPluginTitle();
 	}
 
-		/**
-		 * Check if the current user has the required permissions to install updates.
-		 *
-		 * @return bool
-		 */
+	/**
+	 * Check if the current user has the required permissions to install updates.
+	 *
+	 * @return bool
+	 */
 	public function userCanInstallUpdates()
 	{
 		return current_user_can('update_plugins');
 	}
 
-		/**
-		 * Check if the module file is inside the mu-plugins directory.
-		 *
-		 * @deprecated
-		 * @return bool
-		 */
+	/**
+	 * Check if the module file is inside the mu-plugins directory.
+	 *
+	 * @deprecated
+	 * @return bool
+	 */
 	protected function isMuPlugin()
 	{
 		return $this->package->isMuPlugin();
 	}
 
-		/**
-		 * MU modules are partially supported, but only when we know which file in mu-plugins
-		 * corresponds to this module.
-		 *
-		 * @return bool
-		 */
+	/**
+	 * MU modules are partially supported, but only when we know which file in mu-plugins
+	 * corresponds to this module.
+	 *
+	 * @return bool
+	 */
 	protected function isUnknownMuPlugin()
 	{
 		return empty($this->muPluginFile) && $this->package->isMuPlugin();
 	}
 
-		/**
-		 * Get absolute path to the main module file.
-		 *
-		 * @return string
-		 */
+	/**
+	 * Get absolute path to the main module file.
+	 *
+	 * @return string
+	 */
 	public function getAbsolutePath()
 	{
 		return $this->pluginAbsolutePath;
 	}
 
-		/**
-		 * Register a callback for filtering query arguments.
-		 *
-		 * The callback function should take one argument - an associative array of query arguments.
-		 * It should return a modified array of query arguments.
-		 *
-		 * @uses add_filter() This method is a convenience wrapper for add_filter().
-		 *
-		 * @param callable $callback
-		 * @return void
-		 */
+	/**
+	 * Register a callback for filtering query arguments.
+	 *
+	 * The callback function should take one argument - an associative array of query arguments.
+	 * It should return a modified array of query arguments.
+	 *
+	 * @uses add_filter() This method is a convenience wrapper for add_filter().
+	 *
+	 * @param callable $callback
+	 * @return void
+	 */
 	public function addQueryArgFilter($callback)
 	{
 		$this->addFilter('request_info_query_args', $callback);
 	}
 
-		/**
-		 * Register a callback for filtering arguments passed to wp_remote_get().
-		 *
-		 * The callback function should take one argument - an associative array of arguments -
-		 * and return a modified array or arguments. See the WP documentation on wp_remote_get()
-		 * for details on what arguments are available and how they work.
-		 *
-		 * @uses add_filter() This method is a convenience wrapper for add_filter().
-		 *
-		 * @param callable $callback
-		 * @return void
-		 */
+	/**
+	 * Register a callback for filtering arguments passed to wp_remote_get().
+	 *
+	 * The callback function should take one argument - an associative array of arguments -
+	 * and return a modified array or arguments. See the WP documentation on wp_remote_get()
+	 * for details on what arguments are available and how they work.
+	 *
+	 * @uses add_filter() This method is a convenience wrapper for add_filter().
+	 *
+	 * @param callable $callback
+	 * @return void
+	 */
 	public function addHttpRequestArgFilter($callback)
 	{
 		$this->addFilter('request_info_options', $callback);
 	}
 
-		/**
-		 * Register a callback for filtering the module info retrieved from the external API.
-		 *
-		 * The callback function should take two arguments. If the module info was retrieved
-		 * successfully, the first argument passed will be an instance of  PluginInfo. Otherwise,
-		 * it will be NULL. The second argument will be the corresponding return value of
-		 * wp_remote_get (see WP docs for details).
-		 *
-		 * The callback function should return a new or modified instance of PluginInfo or NULL.
-		 *
-		 * @uses add_filter() This method is a convenience wrapper for add_filter().
-		 *
-		 * @param callable $callback
-		 * @return void
-		 */
+	/**
+	 * Register a callback for filtering the module info retrieved from the external API.
+	 *
+	 * The callback function should take two arguments. If the module info was retrieved
+	 * successfully, the first argument passed will be an instance of  PluginInfo. Otherwise,
+	 * it will be NULL. The second argument will be the corresponding return value of
+	 * wp_remote_get (see WP docs for details).
+	 *
+	 * The callback function should return a new or modified instance of PluginInfo or NULL.
+	 *
+	 * @uses add_filter() This method is a convenience wrapper for add_filter().
+	 *
+	 * @param callable $callback
+	 * @return void
+	 */
 	public function addResultFilter($callback)
 	{
 		$this->addFilter('request_info_result', $callback, 10, 2);
@@ -405,23 +405,24 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p8_UpdateChecker
 		return new \Puc_v4p8_DebugBar_PluginExtension($this);
 	}
 
-		/**
-		 * Create a package instance that represents this plugin or theme.
-		 *
-		 * @return Puc_v4p8_InstalledPackage
-		 */
+	/**
+	 * Create a package instance that represents this plugin or theme.
+	 *
+	 * @return Puc_v4p8_InstalledPackage
+	 */
 	protected function createInstalledPackage()
 	{
 		return new \Puc_v4p8_Plugin_Package($this->pluginAbsolutePath, $this);
 	}
 
-		/**
-		 * @return Puc_v4p8_Plugin_Package
-		 */
+	/**
+	 * @return Puc_v4p8_Plugin_Package
+	 */
 	public function getInstalledPackage()
 	{
 		return $this->package;
 	}
+
 	/* -------------------------------------------------------------------
 	 * JSON-based update API
 	 * -------------------------------------------------------------------

--- a/includes/dependencies/plugin-update-checker/class-osdxp-module-update-checker.php
+++ b/includes/dependencies/plugin-update-checker/class-osdxp-module-update-checker.php
@@ -2,11 +2,11 @@
 /**
  * Module update checker extended from vendor PUC
  *
- * @see   Puc_v4p7_Plugin_UpdateChecker
+ * @see   Puc_v4p8_Plugin_UpdateChecker
  */
 namespace OSDXP_Dashboard;
 
-class OsdxpModuleUpdateChecker extends \Puc_v4p7_UpdateChecker
+class OsdxpModuleUpdateChecker extends \Puc_v4p8_UpdateChecker
 {
 	protected $updateTransient = 'update_plugins';
 	protected $translationType = 'plugin';
@@ -16,7 +16,7 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p7_UpdateChecker
 	public $muPluginFile = ''; //For MU modules, the module filename relative to the mu-plugins directory.
 
 		/**
-		 * @var Puc_v4p7_Plugin_Package
+		 * @var Puc_v4p8_Plugin_Package
 		 */
 	protected $package;
 
@@ -82,11 +82,11 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p7_UpdateChecker
 		 * Create an instance of the scheduler.
 		 *
 		 * @param int $checkPeriod
-		 * @return Puc_v4p7_Scheduler
+		 * @return Puc_v4p8_Scheduler
 		 */
 	protected function createScheduler($checkPeriod)
 	{
-		$scheduler = new \Puc_v4p7_Scheduler($this, $checkPeriod, array('load-plugins.php'));
+		$scheduler = new \Puc_v4p8_Scheduler($this, $checkPeriod, array('load-plugins.php'));
 		register_deactivation_hook($this->pluginFile, array($scheduler, 'removeUpdaterCron'));
 		return $scheduler;
 	}
@@ -134,14 +134,14 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p7_UpdateChecker
 		 * @uses wp_remote_get()
 		 *
 		 * @param array $queryArgs Additional query arguments to append to the request. Optional.
-		 * @return Puc_v4p7_Plugin_Info
+		 * @return Puc_v4p8_Plugin_Info
 		 */
 	public function requestInfo($queryArgs = array())
 	{
-		list($pluginInfo, $result) = $this->requestMetadata('Puc_v4p7_Plugin_Info', 'request_info', $queryArgs);
+		list($pluginInfo, $result) = $this->requestMetadata('Puc_v4p8_Plugin_Info', 'request_info', $queryArgs);
 
 		if ($pluginInfo !== null) {
-			/** @var Puc_v4p7_Plugin_Info $pluginInfo */
+			/** @var Puc_v4p8_Plugin_Info $pluginInfo */
 			$pluginInfo->filename = $this->pluginFile;
 			$pluginInfo->slug = $this->slug;
 		}
@@ -155,7 +155,7 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p7_UpdateChecker
 		 *
 		 * @uses PluginUpdateChecker::requestInfo()
 		 *
-		 * @return Puc_v4p7_Update|null An instance of Plugin_Update, or NULL when no updates are available.
+		 * @return Puc_v4p8_Update|null An instance of Plugin_Update, or NULL when no updates are available.
 		 */
 	public function requestUpdate()
 	{
@@ -165,7 +165,7 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p7_UpdateChecker
 		if ($pluginInfo === null) {
 			return null;
 		}
-		$update = \Puc_v4p7_Plugin_Update::fromPluginInfo($pluginInfo);
+		$update = \Puc_v4p8_Plugin_Update::fromPluginInfo($pluginInfo);
 
 		$update = $this->filterUpdateResult($update);
 
@@ -282,13 +282,13 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p7_UpdateChecker
 		 * Uses cached update data. To retrieve update information straight from
 		 * the metadata URL, call requestUpdate() instead.
 		 *
-		 * @return Puc_v4p7_Plugin_Update|null
+		 * @return Puc_v4p8_Plugin_Update|null
 		 */
 	public function getUpdate()
 	{
 		$update = parent::getUpdate();
 		if (isset($update)) {
-			/** @var Puc_v4p7_Plugin_Update $update */
+			/** @var Puc_v4p8_Plugin_Update $update */
 			$update->filename = $this->pluginFile;
 		}
 		return $update;
@@ -402,21 +402,21 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p7_UpdateChecker
 
 	protected function createDebugBarExtension()
 	{
-		return new \Puc_v4p7_DebugBar_PluginExtension($this);
+		return new \Puc_v4p8_DebugBar_PluginExtension($this);
 	}
 
 		/**
 		 * Create a package instance that represents this plugin or theme.
 		 *
-		 * @return Puc_v4p7_InstalledPackage
+		 * @return Puc_v4p8_InstalledPackage
 		 */
 	protected function createInstalledPackage()
 	{
-		return new \Puc_v4p7_Plugin_Package($this->pluginAbsolutePath, $this);
+		return new \Puc_v4p8_Plugin_Package($this->pluginAbsolutePath, $this);
 	}
 
 		/**
-		 * @return Puc_v4p7_Plugin_Package
+		 * @return Puc_v4p8_Plugin_Package
 		 */
 	public function getInstalledPackage()
 	{
@@ -433,7 +433,7 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p7_UpdateChecker
 	 * @param string $metaClass Parse the JSON as an instance of this class. It must have a static fromJson method.
 	 * @param string $filterRoot
 	 * @param array $queryArgs Additional query arguments.
-	 * @return array [Puc_v4p7_Metadata|null, array|WP_Error]
+	 * @return array [Puc_v4p8_Metadata|null, array|WP_Error]
 	 * A metadata instance and the value returned by wp_remote_get().
 	 */
 	protected function requestMetadata($metaClass, $filterRoot, $queryArgs = array())

--- a/osdxp-dashboard.php
+++ b/osdxp-dashboard.php
@@ -7,7 +7,7 @@
  * Author URI:          http://www.crowdfavorite.com
  * Requires at least:   5.2
  * Requires PHP:        7.2
- * Version:             1.0.2
+ * Version:             1.0.3
  * License:             GPL2
  * License URI:         https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * Text domain:         osdxp-dashboard
@@ -41,7 +41,7 @@ define('OSDXP_DASHBOARD_DIR', plugin_dir_path(OSDXP_DASHBOARD_FILE));
 define('OSDXP_DASHBOARD_URL', plugins_url('/', OSDXP_DASHBOARD_FILE));
 
 // Always mention the plugin version (enclose in quotes so it is processed as a string).
-define('OSDXP_DASHBOARD_VER', '1.0.2');
+define('OSDXP_DASHBOARD_VER', '1.0.3');
 define('OSDXP_DASHBOARD_SITE', 'https://opensourcedxp.com/');
 
 define('OSDXP_DASHBOARD_PLUGIN_NAME', 'Open Source DXP Dashboard');


### PR DESCRIPTION
- Updates `yahnis-elsts/plugin-update-checker` dep to `~4.8.0` (#33, dbf99ec)
- Updates default available modules `json` (503737b)
- Adds slug filtering for modules (503737b)
- Shifted parent updater initialization logic to a point before member access -(#38, #34) 
- Files with effects now loaded by main plugin (#41, #37) 
- Autoload file now loaded only if exists (#40, #39) 