### PR TITLE
Make plugin agnostic of integrations

### DIFF
--- a/templates/dashboard-actions-editor.php
+++ b/templates/dashboard-actions-editor.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Dashboard actions.
  *
@@ -56,64 +57,107 @@
 				</div>
 			</a>
 		<?php endif; ?>
+
+		<?php
+		$custom_create_functionality_modules = [];
+		$custom_create_functionality_modules = apply_filters('osdxp_dashboard_editor_create_functionality', $custom_create_functionality_modules);
+
+		foreach ($custom_create_functionality_modules as $custom_module) {
+			?>
+			<a href="<?php echo esc_url($custom_module['link']); ?>" class="col">
+				<div class="postbox">
+					<div>
+						<div class="group">
+							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
+							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
+							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+						</div>
+						<div class="button button-primary"><?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?></div>
+					</div>
+				</div>
+			</a>
+			<?php
+		}
+		?>
 	</div>
 
 	<h2 class="title"><?php esc_html_e('Manage Functionality', 'osdxp-dashboard'); ?></h2>
 	<div class="row">
 		<?php if (current_user_can('edit_pages')) : ?>
 			<a href="<?php echo admin_url('edit.php?post_type=page');  // phpcs:ignore?>" class="col">
-		 		<div class="postbox">
-		 			<div>
+				<div class="postbox">
+					<div>
 						<div class="group">
 							<div class="dashicons-before dashicons-admin-page"></div>
 							<span><?php esc_html_e('Pages', 'osdxp-dashboard'); ?></span>
 							<p><?php esc_html_e('Manage Pages', 'osdxp-dashboard'); ?></p>
 						</div>
 					</div>
-		 		</div>
-		 	</a>
+				</div>
+			</a>
 		<?php endif; ?>
 
 		<?php if (current_user_can('edit_posts')) : ?>
 			<a href="<?php echo admin_url('edit.php');  // phpcs:ignore?>" class="col">
-		 		<div class="postbox">
-		 			<div>
+				<div class="postbox">
+					<div>
 						<div class="group">
 							<div class="dashicons-before dashicons-text-page"></div>
 							<span><?php esc_html_e('Articles', 'osdxp-dashboard'); ?></span>
 							<p><?php esc_html_e('Manage Articles', 'osdxp-dashboard'); ?></p>
 						</div>
 					</div>
-		 		</div>
-		 	</a>
+				</div>
+			</a>
 		<?php endif; ?>
 
 		<?php if ((current_user_can('publish_pages') || current_user_can('publish_posts')) && class_exists('CFConditionalContent')) :  // phpcs:ignore?>
 			<a href="<?php echo admin_url('admin.php?page=cf-conditional-content-settings');  // phpcs:ignore?>" class="col">
-		 		<div class="postbox">
-		 			<div>
+				<div class="postbox">
+					<div>
 						<div class="group">
 							<div class="dashicons-before dashicons-admin-post"></div>
 							<span><?php esc_html_e('Conditional Content', 'osdxp-dashboard'); ?></span>
 							<p><?php esc_html_e('Manage Conditions', 'osdxp-dashboard'); ?></p>
 						</div>
 					</div>
-		 		</div>
-		 	</a>
+				</div>
+			</a>
 		<?php endif; ?>
 
 		<?php if (current_user_can('upload_files')) : ?>
 			<a href="<?php echo admin_url('upload.php');  // phpcs:ignore?>" class="col">
-		 		<div class="postbox">
-		 			<div>
+				<div class="postbox">
+					<div>
 						<div class="group">
 							<div class="dashicons-before dashicons-admin-media"></div>
 							<span><?php esc_html_e('Media', 'osdxp-dashboard'); ?></span>
 							<p><?php esc_html_e('Manage Media', 'osdxp-dashboard'); ?></p>
 						</div>
 					</div>
-		 		</div>
-		 	</a>
+				</div>
+			</a>
 		<?php endif; ?>
+
+		<?php
+		$custom_manage_functionality_modules = [];
+		$custom_manage_functionality_modules = apply_filters('osdxp_dashboard_editor_manage_functionality', $custom_manage_functionality_modules);
+
+		foreach ($custom_manage_functionality_modules as $custom_module) {
+			?>
+			<a href="<?php echo esc_url($custom_module['link']); ?>" class="col">
+				<div class="postbox">
+					<div>
+						<div class="group">
+							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
+							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
+							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+						</div>
+					</div>
+				</div>
+			</a>
+			<?php
+		}
+		?>
 	</div>
  </div>

--- a/templates/dashboard-actions-multisite-admin.php
+++ b/templates/dashboard-actions-multisite-admin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Dashboard actions.
  *
@@ -60,45 +61,45 @@
 	<div class="row">
 
 		<?php if (current_user_can('create_users')) : ?>
-            <a href="<?php echo admin_url('user-new.php'); // phpcs:ignore?>" class="col">
-                <div class="postbox">
-                    <div>
-                        <div class="group">
-                            <div class="dashicons-before dashicons-admin-users"></div>
-                            <span><?php esc_html_e('Users', 'osdxp-dashboard'); ?></span>
-                            <p><?php esc_html_e('Create New User', 'osdxp-dashboard'); ?></p>
-                        </div>
-                    </div>
-                </div>
-            </a>
+			<a href="<?php echo admin_url('user-new.php'); // phpcs:ignore?>" class="col">
+				<div class="postbox">
+					<div>
+						<div class="group">
+							<div class="dashicons-before dashicons-admin-users"></div>
+							<span><?php esc_html_e('Users', 'osdxp-dashboard'); ?></span>
+							<p><?php esc_html_e('Create New User', 'osdxp-dashboard'); ?></p>
+						</div>
+					</div>
+				</div>
+			</a>
 		<?php endif; ?>
 
 		<?php if (current_user_can('publish_pages')) : ?>
 			<a href="<?php echo admin_url('post-new.php?post_type=page');  // phpcs:ignore?>" class="col">
-		 		<div class="postbox">
-		 			<div>
+				<div class="postbox">
+					<div>
 						<div class="group">
 							<div class="dashicons-before dashicons-admin-page"></div>
 							<span><?php esc_html_e('Pages', 'osdxp-dashboard'); ?></span>
 							<p><?php esc_html_e('Create New Page', 'osdxp-dashboard'); ?></p>
 						</div>
 					</div>
-		 		</div>
-		 	</a>
+				</div>
+			</a>
 		<?php endif; ?>
 
 		<?php if (current_user_can('edit_theme_options')) : ?>
 			<a href="<?php echo admin_url('nav-menus.php?action=edit&menu=0');  // phpcs:ignore?>" class="col">
-		 		<div class="postbox">
-		 			<div>
+				<div class="postbox">
+					<div>
 						<div class="group">
 							<div class="dashicons-before dashicons-menu-alt"></div>
 							<span><?php esc_html_e('Menus', 'osdxp-dashboard'); ?></span>
 							<p><?php esc_html_e('Create New Menu', 'osdxp-dashboard'); ?></p>
 						</div>
 					</div>
-		 		</div>
-		 	</a>
+				</div>
+			</a>
 		<?php endif; ?>
 
 		<?php

--- a/templates/dashboard-actions-multisite-admin.php
+++ b/templates/dashboard-actions-multisite-admin.php
@@ -108,7 +108,7 @@
 
 		foreach ($custom_create_functionality_modules as $custom_module) {
 			?>
-			<a href="<?php esc_url($custom_module['link']); ?>" class="col">
+			<a href="<?php echo esc_url($custom_module['link']); ?>" class="col">
 				<div class="postbox">
 					<div>
 						<div class="group">

--- a/templates/dashboard-actions-multisite-admin.php
+++ b/templates/dashboard-actions-multisite-admin.php
@@ -55,6 +55,28 @@
 				</div>
 			</a>
 		<?php endif; ?>
+
+		<?php
+		$custom_manage_functionality_modules = [];
+		$custom_manage_functionality_modules = apply_filters('osdxp_dashboard_multisite_manage_functionality', $custom_manage_functionality_modules);
+
+		foreach ($custom_manage_functionality_modules as $custom_module) {
+			?>
+			<a href="<?php echo esc_url($custom_module['link']); ?>" class="col">
+				<div class="postbox">
+					<div>
+						<div class="group">
+							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
+							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
+							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+						</div>
+						<div class="button button-primary"><?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?></div>
+					</div>
+				</div>
+			</a>
+			<?php
+		}
+		?>
 	</div>
 
 	<h2 class="title"><?php esc_html_e('Create Functionality', 'osdxp-dashboard'); ?></h2>
@@ -104,7 +126,7 @@
 
 		<?php
 		$custom_create_functionality_modules = [];
-		$custom_create_functionality_modules = apply_filters('osdxp_dashboard_create_functionality', $custom_create_functionality_modules);
+		$custom_create_functionality_modules = apply_filters('osdxp_dashboard_multisite_create_functionality', $custom_create_functionality_modules);
 
 		foreach ($custom_create_functionality_modules as $custom_module) {
 			?>
@@ -122,7 +144,6 @@
 			<?php
 		}
 		?>
-
 	</div>
 
  </div>

--- a/templates/dashboard-actions-multisite-admin.php
+++ b/templates/dashboard-actions-multisite-admin.php
@@ -102,24 +102,24 @@
 		<?php endif; ?>
 
 		<?php
-        if (is_plugin_active('multilingualpress/multilingualpress.php')) {
-            $language_manager = (array)get_network_option(0, 'multilingualpress_modules', []);
-            if (! empty($language_manager) && ! empty($language_manager['language-manager'])) {
-                ?>
-                    <a href="/wp-admin/network/admin.php?page=language-manager" class="col">
-                        <div class="postbox">
-                            <div>
-                                <div class="group">
-                                    <div class="dashicons-before dashicons-admin-site-alt3"></div>
-                                    <span><?php esc_html_e('Settings', 'osdxp-dashboard'); ?></span>
-                                    <p><?php esc_html_e('Add New Language', 'osdxp-dashboard'); ?></p>
-                                </div>
-                            </div>
-                        </div>
-                    </a>
-					<?php
-            }
-        }
+		$custom_create_functionality_modules = [];
+		$custom_create_functionality_modules = apply_filters('osdxp_dashboard_create_functionality', $custom_create_functionality_modules);
+
+		foreach ($custom_create_functionality_modules as $custom_module) {
+			?>
+			<a href="<?php esc_url($custom_module['link']); ?>" class="col">
+				<div class="postbox">
+					<div>
+						<div class="group">
+							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
+							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
+							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+						</div>
+					</div>
+				</div>
+			</a>
+			<?php
+		}
 		?>
 
 	</div>

--- a/templates/dashboard-actions-network-admin.php
+++ b/templates/dashboard-actions-network-admin.php
@@ -54,28 +54,6 @@
 				</div>
 			</a>
 		<?php endif; ?>
-
-        <?php
-        $custom_create_functionality_modules = [];
-        $custom_create_functionality_modules = apply_filters('osdxp_dashboard_create_functionality', $custom_create_functionality_modules);
-
-        foreach ($custom_create_functionality_modules as $custom_module) {
-            ?>
-            <a href="<?php esc_url($custom_module['link']); ?>" class="col">
-				<div class="postbox">
-					<div>
-						<div class="group">
-							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
-							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
-							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
-						</div>
-						<div class="button button-primary"><?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?></div>
-					</div>
-				</div>
-			</a>
-            <?php
-        }
-        ?>
 	</div>
 
 	<h2 class="title"><?php esc_html_e('Manage Functionality', 'osdxp-dashboard'); ?></h2>
@@ -123,24 +101,24 @@
 		<?php endif; ?>
 
 		<?php
-        $custom_manage_functionality_modules = [];
-        $custom_manage_functionality_modules = apply_filters('osdxp_dashboard_manage_functionality', $custom_manage_functionality_modules);
+		$custom_create_functionality_modules = [];
+		$custom_create_functionality_modules = apply_filters('osdxp_dashboard_create_functionality', $custom_create_functionality_modules);
 
-        foreach ($custom_manage_functionality_modules as $custom_module) {
-            ?>
-            <a href="<?php esc_url($custom_module['link']); ?>" class="col">
-                <div class="postbox">
-                    <div>
-                        <div class="group">
-                            <div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
-                            <span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
-                            <p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
-                        </div>
-                    </div>
-                </div>
-            </a>
-            <?php
-        }
-        ?>
+		foreach ($custom_create_functionality_modules as $custom_module) {
+			?>
+			<a href="<?php esc_url($custom_module['link']); ?>" class="col">
+				<div class="postbox">
+					<div>
+						<div class="group">
+							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
+							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
+							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+						</div>
+					</div>
+				</div>
+			</a>
+			<?php
+		}
+		?>
 	</div>
  </div>

--- a/templates/dashboard-actions-network-admin.php
+++ b/templates/dashboard-actions-network-admin.php
@@ -101,10 +101,10 @@
 		<?php endif; ?>
 
 		<?php
-		$custom_create_functionality_modules = [];
-		$custom_create_functionality_modules = apply_filters('osdxp_dashboard_create_functionality', $custom_create_functionality_modules);
+		$custom_manage_functionality_modules = [];
+		$custom_manage_functionality_modules = apply_filters('osdxp_dashboard_manage_functionality', $custom_manage_functionality_modules);
 
-		foreach ($custom_create_functionality_modules as $custom_module) {
+		foreach ($custom_manage_functionality_modules as $custom_module) {
 			?>
 			<a href="<?php esc_url($custom_module['link']); ?>" class="col">
 				<div class="postbox">

--- a/templates/dashboard-actions-network-admin.php
+++ b/templates/dashboard-actions-network-admin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Dashboard actions.
  *
@@ -60,44 +61,44 @@
 	<div class="row">
 		<?php if (current_user_can('create_users')) : ?>
 			<a href="<?php echo network_admin_url('users.php');  // phpcs:ignore?>" class="col">
-		 		<div class="postbox">
-		 			<div>
+				<div class="postbox">
+					<div>
 						<div class="group">
 							<div class="dashicons-before dashicons-admin-users"></div>
 							<span><?php esc_html_e('Users', 'osdxp-dashboard'); ?></span>
 							<p><?php esc_html_e('Manage Users', 'osdxp-dashboard'); ?></p>
 						</div>
 					</div>
-		 		</div>
-		 	</a>
+				</div>
+			</a>
 		<?php endif; ?>
 
 		<?php if (current_user_can('create_sites')) : ?>
 			<a href="<?php echo network_admin_url('sites.php');  // phpcs:ignore?>" class="col">
-		 		<div class="postbox">
-		 			<div>
+				<div class="postbox">
+					<div>
 						<div class="group">
 							<div class="dashicons-before dashicons-admin-multisite"></div>
 							<span><?php esc_html_e('Sites', 'osdxp-dashboard'); ?></span>
 							<p><?php esc_html_e('Manage Sites', 'osdxp-dashboard'); ?></p>
 						</div>
 					</div>
-		 		</div>
-		 	</a>
+				</div>
+			</a>
 		<?php endif; ?>
 
 		<?php if (current_user_can('install_plugins')) : ?>
 			<a href="<?php echo network_admin_url('plugins.php');  // phpcs:ignore?>" class="col">
-		 		<div class="postbox">
-		 			<div>
+				<div class="postbox">
+					<div>
 						<div class="group">
 							<div class="dashicons-before dashicons-admin-generic"></div>
 							<span><?php esc_html_e('Modules', 'osdxp-dashboard'); ?></span>
 							<p><?php esc_html_e('Manage Modules', 'osdxp-dashboard'); ?></p>
 						</div>
 					</div>
-		 		</div>
-		 	</a>
+				</div>
+			</a>
 		<?php endif; ?>
 
 		<?php

--- a/templates/dashboard-actions-network-admin.php
+++ b/templates/dashboard-actions-network-admin.php
@@ -107,7 +107,7 @@
 
 		foreach ($custom_manage_functionality_modules as $custom_module) {
 			?>
-			<a href="<?php esc_url($custom_module['link']); ?>" class="col">
+			<a href="<?php echo esc_url($custom_module['link']); ?>" class="col">
 				<div class="postbox">
 					<div>
 						<div class="group">

--- a/templates/dashboard-actions-network-admin.php
+++ b/templates/dashboard-actions-network-admin.php
@@ -54,6 +54,28 @@
 				</div>
 			</a>
 		<?php endif; ?>
+
+        <?php
+        $custom_create_functionality_modules = [];
+        $custom_create_functionality_modules = apply_filters('osdxp_dashboard_create_functionality', $custom_create_functionality_modules);
+
+        foreach ($custom_create_functionality_modules as $custom_module) {
+            ?>
+            <a href="<?php esc_url($custom_module['link']); ?>" class="col">
+				<div class="postbox">
+					<div>
+						<div class="group">
+							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
+							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
+							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+						</div>
+						<div class="button button-primary"><?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?></div>
+					</div>
+				</div>
+			</a>
+            <?php
+        }
+        ?>
 	</div>
 
 	<h2 class="title"><?php esc_html_e('Manage Functionality', 'osdxp-dashboard'); ?></h2>
@@ -101,23 +123,23 @@
 		<?php endif; ?>
 
 		<?php
-        if (is_plugin_active('multilingualpress/multilingualpress.php')) {
-            $language_manager = (array)get_network_option(0, 'multilingualpress_modules', []);
-            if (! empty($language_manager) && ! empty($language_manager['language-manager'])) {
-                ?>
-                        <a href="/wp-admin/network/admin.php?page=language-manager" class="col">
-                            <div class="postbox">
-                                <div>
-                                    <div class="group">
-                                        <div class="dashicons-before dashicons-admin-settings"></div>
-                                        <span><?php esc_html_e('Settings', 'osdxp-dashboard'); ?></span>
-                                        <p><?php esc_html_e('Manage Languages', 'osdxp-dashboard'); ?></p>
-                                    </div>
-                                </div>
-                            </div>
-                        </a>
-				    <?php
-            }
+        $custom_manage_functionality_modules = [];
+        $custom_manage_functionality_modules = apply_filters('osdxp_dashboard_manage_functionality', $custom_manage_functionality_modules);
+
+        foreach ($custom_manage_functionality_modules as $custom_module) {
+            ?>
+            <a href="<?php esc_url($custom_module['link']); ?>" class="col">
+                <div class="postbox">
+                    <div>
+                        <div class="group">
+                            <div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
+                            <span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
+                            <p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+                        </div>
+                    </div>
+                </div>
+            </a>
+            <?php
         }
         ?>
 	</div>

--- a/templates/dashboard-actions-network-admin.php
+++ b/templates/dashboard-actions-network-admin.php
@@ -55,6 +55,28 @@
 				</div>
 			</a>
 		<?php endif; ?>
+
+		<?php
+		$custom_create_functionality_modules = [];
+		$custom_create_functionality_modules = apply_filters('osdxp_dashboard_network_create_functionality', $custom_create_functionality_modules);
+
+		foreach ($custom_create_functionality_modules as $custom_module) {
+			?>
+			<a href="<?php echo esc_url($custom_module['link']); ?>" class="col">
+				<div class="postbox">
+					<div>
+						<div class="group">
+							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
+							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
+							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+						</div>
+						<div class="button button-primary"><?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?></div>
+					</div>
+				</div>
+			</a>
+			<?php
+		}
+		?>
 	</div>
 
 	<h2 class="title"><?php esc_html_e('Manage Functionality', 'osdxp-dashboard'); ?></h2>
@@ -103,7 +125,7 @@
 
 		<?php
 		$custom_manage_functionality_modules = [];
-		$custom_manage_functionality_modules = apply_filters('osdxp_dashboard_manage_functionality', $custom_manage_functionality_modules);
+		$custom_manage_functionality_modules = apply_filters('osdxp_dashboard_network_manage_functionality', $custom_manage_functionality_modules);
 
 		foreach ($custom_manage_functionality_modules as $custom_module) {
 			?>

--- a/templates/dashboard-actions-single-admin.php
+++ b/templates/dashboard-actions-single-admin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Dashboard actions.
  *
@@ -54,36 +55,58 @@
 				</div>
 			</a>
 		<?php endif; ?>
+
+		<?php
+		$custom_manage_functionality_modules = [];
+		$custom_manage_functionality_modules = apply_filters('osdxp_dashboard_single_manage_functionality', $custom_manage_functionality_modules);
+
+		foreach ($custom_manage_functionality_modules as $custom_module) {
+			?>
+			<a href="<?php echo esc_url($custom_module['link']); ?>" class="col">
+				<div class="postbox">
+					<div>
+						<div class="group">
+							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
+							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
+							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+						</div>
+						<div class="button button-primary"><?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?></div>
+					</div>
+				</div>
+			</a>
+			<?php
+		}
+		?>
 	</div>
 
 	<h2 class="title"><?php esc_html_e('Create Functionality', 'osdxp-dashboard'); ?></h2>
 	<div class="row">
 		<?php if (current_user_can('create_users')) : ?>
 			<a href="<?php echo admin_url('user-new.php');  // phpcs:ignore?>" class="col">
-		 		<div class="postbox">
-		 			<div>
+				<div class="postbox">
+					<div>
 						<div class="group">
 							<div class="dashicons-before dashicons-admin-users"></div>
 							<span><?php esc_html_e('Users', 'osdxp-dashboard'); ?></span>
 							<p><?php esc_html_e('Create New User', 'osdxp-dashboard'); ?></p>
 						</div>
 					</div>
-		 		</div>
-		 	</a>
+				</div>
+			</a>
 		<?php endif; ?>
 
 		<?php if (current_user_can('publish_pages')) : ?>
 			<a href="<?php echo admin_url('post-new.php?post_type=page');  // phpcs:ignore?>" class="col">
-		 		<div class="postbox">
-		 			<div>
+				<div class="postbox">
+					<div>
 						<div class="group">
 							<div class="dashicons-before dashicons-admin-page"></div>
 							<span><?php esc_html_e('Pages', 'osdxp-dashboard'); ?></span>
 							<p><?php esc_html_e('Create New Page', 'osdxp-dashboard'); ?></p>
 						</div>
 					</div>
-		 		</div>
-		 	</a>
+				</div>
+			</a>
 		<?php endif; ?>
 
 		<?php if (current_user_can('install_plugins')) : ?>
@@ -102,17 +125,38 @@
 
 		<?php if (current_user_can('edit_theme_options')) : ?>
 			<a href="<?php echo admin_url('nav-menus.php?action=edit&menu=0');  // phpcs:ignore?>" class="col">
-		 		<div class="postbox">
-		 			<div>
+				<div class="postbox">
+					<div>
 						<div class="group">
 							<div class="dashicons-before dashicons-menu-alt"></div>
 							<span><?php esc_html_e('Menus', 'osdxp-dashboard'); ?></span>
 							<p><?php esc_html_e('Create New Menu', 'osdxp-dashboard'); ?></p>
 						</div>
 					</div>
-		 		</div>
-		 	</a>
+				</div>
+			</a>
 		<?php endif; ?>
+
+		<?php
+		$custom_create_functionality_modules = [];
+		$custom_create_functionality_modules = apply_filters('osdxp_dashboard_single_create_functionality', $custom_create_functionality_modules);
+
+		foreach ($custom_create_functionality_modules as $custom_module) {
+			?>
+			<a href="<?php echo esc_url($custom_module['link']); ?>" class="col">
+				<div class="postbox">
+					<div>
+						<div class="group">
+							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
+							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
+							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+						</div>
+					</div>
+				</div>
+			</a>
+			<?php
+		}
+		?>
 	</div>
 
  </div>


### PR DESCRIPTION
To allow 3rd party plugins or partners to add custom widgets to the OSDXP dashboard admin screens added bellow hooks.
 
- add `osdxp_dashboard_create_functionality` hook for multisite admin dashboard page
 - add `osdxp_dashboard_manage_functionality` hook for network admin dashboard page

This is related and closes ticket #15