### PR TITLE
1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 A historical record of notable changes to `osdxp-dashboard` will be documented in this file.
 
+## [v1.1.0 (2019-11-29)](https://github.com/osDXP/osdxp-dashboard/releases/tag/v1.1.0)
+- Update repository meta files
+- Make plugin agnostic of integrations
+- Register assets by default and only enqueue them conditionally
+- Use SCRIPT_DEBUG instead of WP_DEBUG when deciding what type of assets to load (production or development)
+
 ## [v1.0.3 (2019-11-05)](https://github.com/osDXP/osdxp-dashboard/releases/tag/v1.0.3)
 - Update default available modules `json`
 - Add slug filtering for modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 A historical record of notable changes to `osdxp-dashboard` will be documented in this file.
 
-## [v1.1.0 (2019-11-29)](https://github.com/osDXP/osdxp-dashboard/releases/tag/v1.1.0)
+## [v1.1.0 (2019-12-05)](https://github.com/osDXP/osdxp-dashboard/releases/tag/v1.1.0)
 - Update repository meta files
 - Make plugin agnostic of integrations
 - Register assets by default and only enqueue them conditionally

--- a/includes/class-licenseapi.php
+++ b/includes/class-licenseapi.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * API integration with license server.
  *
@@ -16,7 +17,7 @@ class LicenseAPI
 	 *
 	 * @var string
 	 */
-	const USER_AGENT = 'OSDXP-DASHBOARD';
+	private const USER_AGENT = 'OSDXP-DASHBOARD';
 
 	/**
 	 * The user's API key.

--- a/includes/class-osdxp-render-available-modules.php
+++ b/includes/class-osdxp-render-available-modules.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This class provides functionality to obtain and display the openDXP
  * available modules.

--- a/includes/config.php
+++ b/includes/config.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * File containing the configuration of various plugin elements.
  *
@@ -89,7 +90,8 @@ function get_dxp_menu_pages()
 		$custom_pages = apply_filters('osdxp_add_module_settings_page', $custom_pages);
 
 		foreach ($custom_pages as $custom_page) {
-			if (isset($custom_page['page_title'])
+			if (
+				isset($custom_page['page_title'])
 				&& isset($custom_page['menu_title'])
 				&& isset($custom_page['menu_slug'])
 				&& isset($custom_page['function'])

--- a/includes/core.php
+++ b/includes/core.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * File containing core functionality.
  *

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * File containing dashboard functionality.
  *

--- a/includes/dependencies/plugin-update-checker/class-osdxp-module-update-checker-ui.php
+++ b/includes/dependencies/plugin-update-checker/class-osdxp-module-update-checker-ui.php
@@ -1,10 +1,12 @@
 <?php
+
 /**
  * Module Update Checker UI
  * This adds extra links to module table view to check for updates & extra
  *
  * @see   Puc_v4p8_Plugin_Ui
  */
+
 namespace OSDXP_Dashboard;
 
 /**

--- a/includes/dependencies/plugin-update-checker/class-osdxp-module-update-checker.php
+++ b/includes/dependencies/plugin-update-checker/class-osdxp-module-update-checker.php
@@ -1,9 +1,11 @@
 <?php
+
 /**
  * Module update checker extended from vendor PUC
  *
  * @see   Puc_v4p8_Plugin_UpdateChecker
  */
+
 namespace OSDXP_Dashboard;
 
 class OsdxpModuleUpdateChecker extends \Puc_v4p8_UpdateChecker
@@ -63,7 +65,7 @@ class OsdxpModuleUpdateChecker extends \Puc_v4p8_UpdateChecker
 		}
 		add_filter($slugCheckFilter, array($this, 'getAbsolutePath'));
 
-        parent::__construct($metadataUrl, dirname($this->pluginFile), $slug, $checkPeriod, $optionName);
+		parent::__construct($metadataUrl, dirname($this->pluginFile), $slug, $checkPeriod, $optionName);
 
 		//Backwards compatibility: If the module is a mu-plugin but no $muPluginFile is specified, assume
 		//it's the same as $pluginFile given that it's not in a subdirectory (WP only looks in the base dir).

--- a/includes/dependencies/wordpress/class-osdxp-bulk-module-upgrader-skin.php
+++ b/includes/dependencies/wordpress/class-osdxp-bulk-module-upgrader-skin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Upgrader API: CF_Bulk_Module_Upgrader_Skin class
  *

--- a/includes/dependencies/wordpress/class-osdxp-module-installer-skin.php
+++ b/includes/dependencies/wordpress/class-osdxp-module-installer-skin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Upgrader API: OSDXP_Module_Installer_Skin class
  *

--- a/includes/dependencies/wordpress/class-osdxp-module-upgrader-skin.php
+++ b/includes/dependencies/wordpress/class-osdxp-module-upgrader-skin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Upgrader API: OSDXP_Module_Upgrader_Skin class
  *
@@ -14,7 +15,9 @@
  */
 
 /** Plugin_Upgrader_Skin class */
+// phpcs:disable
 require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php';
+// phpcs:enable
 
 class OSDXP_Module_Upgrader_Skin extends WP_Upgrader_Skin
 {
@@ -57,27 +60,27 @@ class OSDXP_Module_Upgrader_Skin extends WP_Upgrader_Skin
 		$this->module = $this->upgrader->plugin_info();
 		if (! empty($this->module) && ! is_wp_error($this->result) && $this->module_active) {
 			if ('osdxp-dashboard/osdxp-dashboard.php' === $this->module) {
-				echo '<iframe title="' . esc_attr__('Update progress') . '" style="border:0;overflow:hidden" width="100%" height="30" src="' . wp_nonce_url('update.php?action=activate-plugin&networkwide=' . $this->module_network_active . '&plugin=' . urlencode($this->module), 'activate-plugin_' . $this->module) . '"></iframe>';
+				echo '<iframe title="' . esc_attr__('Update progress') . '" style="border:0;overflow:hidden" width="100%" height="30" src="' . wp_nonce_url('update.php?action=activate-plugin&networkwide=' . $this->module_network_active . '&plugin=' . urlencode($this->module), 'activate-plugin_' . $this->module) . '"></iframe>'; // phpcs:ignore
 			} else {
 				// Currently used only when JS is off for a single plugin update?
-				echo '<iframe title="' . esc_attr__('Update progress') . '" style="border:0;overflow:hidden" width="100%" height="18" src="' . esc_url_raw(wp_nonce_url('admin.php?page=dxp-modules-update&noheader&action=activate-module&networkwide=' . $this->module_network_active . '&module=' . urlencode($this->module), 'activate-module_' . $this->module)) . '"></iframe>';
+				echo '<iframe title="' . esc_attr__('Update progress') . '" style="border:0;overflow:hidden" width="100%" height="18" src="' . esc_url_raw(wp_nonce_url('admin.php?page=dxp-modules-update&noheader&action=activate-module&networkwide=' . $this->module_network_active . '&module=' . urlencode($this->module), 'activate-module_' . $this->module)) . '"></iframe>'; // phpcs:ignore
 			}
 		}
 
 		$this->decrement_update_count('plugin');
 		if ('osdxp-dashboard/osdxp-dashboard.php' === $this->module) {
 			$update_actions = array(
-				'activate_module' => '<a href="' . wp_nonce_url('plugins.php?action=activate&amp;plugin=' . urlencode($this->module), 'activate-plugin_' . $this->module) . '" target="_parent">' . __('Activate Module') . '</a>',
-				'plugins_page'    => '<a href="' . self_admin_url('admin.php?page=dxp-modules-installed') . '" target="_parent">' . __('Return to Modules page') . '</a>',
+				'activate_module' => '<a href="' . wp_nonce_url('plugins.php?action=activate&amp;plugin=' . urlencode($this->module), 'activate-plugin_' . $this->module) . '" target="_parent">' . __('Activate Module') . '</a>', // phpcs:ignore
+				'plugins_page'    => '<a href="' . self_admin_url('admin.php?page=dxp-modules-installed') . '" target="_parent">' . __('Return to Modules page') . '</a>', // phpcs:ignore
 			);
 		} else {
 			$update_actions = array(
-				'activate_module' => '<a href="' . esc_url_raw(wp_nonce_url('admin.php?page=dxp-modules-installed&action=activate&module=' . urlencode($this->module), 'activate-module_' . $this->module)) . '" target="_parent">' . __('Activate Module') . '</a>',
-				'plugins_page'    => '<a href="' . self_admin_url('admin.php?page=dxp-modules-installed') . '" target="_parent">' . __('Return to Modules page') . '</a>',
+				'activate_module' => '<a href="' . esc_url_raw(wp_nonce_url('admin.php?page=dxp-modules-installed&action=activate&module=' . urlencode($this->module), 'activate-module_' . $this->module)) . '" target="_parent">' . __('Activate Module') . '</a>', // phpcs:ignore
+				'plugins_page'    => '<a href="' . self_admin_url('admin.php?page=dxp-modules-installed') . '" target="_parent">' . __('Return to Modules page') . '</a>', // phpcs:ignore
 			);
 		}
 
-		if ($this->module_active || ! $this->result || is_wp_error($this->result) || ! current_user_can('activate_plugin', $this->module)) {
+		if ($this->module_active || ! $this->result || is_wp_error($this->result) || ! current_user_can('activate_plugin', $this->module)) { // phpcs:ignore
 			unset($update_actions['activate_module']);
 		}
 

--- a/includes/dependencies/wordpress/class-osdxp-module-upgrader.php
+++ b/includes/dependencies/wordpress/class-osdxp-module-upgrader.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Upgrade API: OSDXP_Module_Upgrader class
  *

--- a/includes/dependencies/wordpress/class-osdxp-modules-list-table.php
+++ b/includes/dependencies/wordpress/class-osdxp-modules-list-table.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * List Table API: OSDXP_Modules_List_Table class
  *
@@ -6,6 +7,7 @@
  *
  * @package osdxp-dashboard
  */
+
 namespace OSDXP_Dashboard;
 
 /** WP_List_Table class */
@@ -220,8 +222,10 @@ class OSDXP_Modules_List_Table extends \WP_List_Table
 					// On the non-network screen, filter out network-active modules
 					unset($modules['all'][ $module_file ]);
 				}
-			} elseif (( ! $screen->in_admin('network') && is_plugin_active($module_file) )
-				|| ( $screen->in_admin('network') && is_plugin_active_for_network($module_file) ) ) {
+			} elseif (
+				( ! $screen->in_admin('network') && is_plugin_active($module_file) )
+				|| ( $screen->in_admin('network') && is_plugin_active_for_network($module_file) )
+			) {
 				// On the non-network screen, populate the active list with modules that are individually activated
 				// On the network-admin screen, populate the active list with modules that are network activated
 				$modules['active'][ $module_file ] = $module_data;
@@ -665,11 +669,11 @@ class OSDXP_Modules_List_Table extends \WP_List_Table
 				$is_active   = false;
 				$description = '<p><strong>' . $dropins[ $module_file ][0] . ' <span class="error-message">' . esc_html__('Inactive:', 'osdxp-dashboard') . '</span></strong> ' .
 					sprintf(
-						/* translators: 1: drop-in constant name, 2: wp-config.php */
+					/* translators: 1: drop-in constant name, 2: wp-config.php */
 						__('Requires %1$s in %2$s file.'),
-						"<code>define('" . $dropins[ $module_file ][1] . "', true);</code>",
-						'<code>wp-config.php</code>'
-					) . '</p>';
+					"<code>define('" . $dropins[ $module_file ][1] . "', true);</code>",
+					'<code>wp-config.php</code>'
+				) . '</p>';
 			}
 			if ($module_data['Description']) {
 				$description .= '<p>' . $module_data['Description'] . '</p>';

--- a/includes/dependencies/wordpress/modules-print-updates.php
+++ b/includes/dependencies/wordpress/modules-print-updates.php
@@ -76,7 +76,7 @@ function osdxp_module_update_row($file, $module_data)
 
 		echo '<tr class="plugin-update-tr' . $active_class . '" id="' . esc_attr($response->slug . '-update') . '" data-slug="' . esc_attr($response->slug) . '" data-plugin="' . esc_attr($file) . '"><td colspan="4" class="plugin-update colspanchange"><div class="update-message notice inline ' . $notice_type . ' notice-alt"><p>';
 
-		if (! current_user_can('update_plugins')) {
+		if (!current_user_can('update_plugins')) {
 			/* translators: 1: module name, 2: details URL, 3: additional link attributes, 4: version number */
 			printf(
 				__('There is a new version of %1$s available. <a href="%2$s" %3$s>View version %4$s details</a>.'),

--- a/includes/licensing.php
+++ b/includes/licensing.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * File containing licensing functionality.
  *

--- a/includes/menus.php
+++ b/includes/menus.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * File containing hooks and functionality related to menus.
  *
@@ -49,7 +50,8 @@ function hide_endpoints_from_sidebar()
 
 	foreach ($dxp_menu_pages as $menu_page) {
 		// Validate and confirm endpoint, check if it's being displayed(has parent_slug)
-		if (is_valid_dxp_menu_page($menu_page)
+		if (
+			is_valid_dxp_menu_page($menu_page)
 			&& $menu_page['type'] === OSDXP_DASHBOARD_MENU_TYPE_ENDPOINT
 			&& isset($menu_page['parent_slug'])
 		) {

--- a/includes/modules.php
+++ b/includes/modules.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * File containing modules functionality.
  *

--- a/includes/notifications.php
+++ b/includes/notifications.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * File containing the notification hiding logic.
  *

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * File containing various functions used throughout the plugin.
  *

--- a/osdxp-dashboard.php
+++ b/osdxp-dashboard.php
@@ -82,26 +82,26 @@ define('OSDXP_DASHBOARD_MENU_TYPE_ENDPOINT', 'endpoint');
 // phpcs:enable
 
 call_user_func_array(function ($absPath, $rootPath, $mainFilePath) {
-    // We need get_plugins to filter for modules
-    if (!function_exists('get_plugins')) {
-        require_once "{$absPath}wp-admin/includes/plugin.php";
-    }
+	// We need get_plugins to filter for modules
+	if (!function_exists('get_plugins')) {
+		require_once "{$absPath}wp-admin/includes/plugin.php";
+	}
 
-    $autoload = "{$rootPath}vendor/autoload.php";
-    if (is_readable($autoload)) {
-        require_once $autoload;
-    }
+	$autoload = "{$rootPath}vendor/autoload.php";
+	if (is_readable($autoload)) {
+		require_once $autoload;
+	}
 
-    require_once "{$rootPath}includes/assets.php";
-    require_once "{$rootPath}includes/config.php";
-    require_once "{$rootPath}includes/core.php";
-    require_once "{$rootPath}includes/dashboard.php";
-    require_once "{$rootPath}includes/licensing.php";
-    require_once "{$rootPath}includes/menus.php";
-    require_once "{$rootPath}includes/modules.php";
-    require_once "{$rootPath}includes/utils.php";
-    require_once "{$rootPath}includes/notifications.php";
+	require_once "{$rootPath}includes/assets.php";
+	require_once "{$rootPath}includes/config.php";
+	require_once "{$rootPath}includes/core.php";
+	require_once "{$rootPath}includes/dashboard.php";
+	require_once "{$rootPath}includes/licensing.php";
+	require_once "{$rootPath}includes/menus.php";
+	require_once "{$rootPath}includes/modules.php";
+	require_once "{$rootPath}includes/utils.php";
+	require_once "{$rootPath}includes/notifications.php";
 
-    register_deactivation_hook($mainFilePath, __NAMESPACE__ . '\\osdxp_deactivate');
-    register_activation_hook($mainFilePath, __NAMESPACE__ . '\\osdxp_activate');
+	register_deactivation_hook($mainFilePath, __NAMESPACE__ . '\\osdxp_deactivate');
+	register_activation_hook($mainFilePath, __NAMESPACE__ . '\\osdxp_activate');
 }, [ABSPATH, OSDXP_DASHBOARD_DIR, OSDXP_DASHBOARD_FILE]);

--- a/osdxp-dashboard.php
+++ b/osdxp-dashboard.php
@@ -8,7 +8,7 @@
  * Author URI:          https://osdxp.org
  * Requires at least:   5.2
  * Requires PHP:        7.2
- * Version:             1.0.3
+ * Version:             1.1.0
  * License:             GPL2
  * License URI:         https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * Text domain:         osdxp-dashboard
@@ -42,7 +42,7 @@ define('OSDXP_DASHBOARD_DIR', plugin_dir_path(OSDXP_DASHBOARD_FILE));
 define('OSDXP_DASHBOARD_URL', plugins_url('/', OSDXP_DASHBOARD_FILE));
 
 // Always mention the plugin version (enclose in quotes so it is processed as a string).
-define('OSDXP_DASHBOARD_VER', '1.0.3');
+define('OSDXP_DASHBOARD_VER', '1.1.0');
 define('OSDXP_DASHBOARD_SITE', 'https://osdxp.org/');
 
 define('OSDXP_DASHBOARD_PLUGIN_NAME', 'Open Source DXP Dashboard');
@@ -73,7 +73,7 @@ define('OSDXP_DASHBOARD_NEWS_RSS_MAX_ITEMS_COUNT', 5);
 
 // Define the plugin assets handle, this is used to give unique names to the plugin scripts.
 define('OSDXP_DASHBOARD_HANDLE', 'osdxp-dashboard');
-define('OSDXP_DASHBOARD_LOCALIZED_OBJECT_NAME', 'OSDXPDashboard');
+define('OSDXP_DASHBOARD_LOCALIZED_OBJECT_NAME', 'osDXPDashboard');
 
 // Define page types available to add
 define('OSDXP_DASHBOARD_MENU_TYPE_MENU', 'menu');

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -50,6 +50,7 @@
 	<!-- Exclude node and vendor directories -->
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/dependencies/*</exclude-pattern>
 
 	<!-- Check the files in the project directory. Where this xml file should be located. -->
 	<file>.</file>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,9 +2,6 @@
 <ruleset name="osDXP PSR12-based Coding Standards">
 	<description>Custom variant of PSR12 with WordPress security checks for PHP development</description>
 
-	<!-- Include PHPCompatibility to allow for checking code for PHP version compatibility -->
-	<rule ref="PHPCompatibility"/>
-
 	<!-- Default ruleset is PSR12 with one exception - tabs instead of spaces is allowed and preferred -->
 	<rule ref="PSR12">
 		<exclude name="Generic.WhiteSpace.DisallowTabIndent"/>

--- a/templates/dashboard-actions-editor.php
+++ b/templates/dashboard-actions-editor.php
@@ -60,7 +60,10 @@
 
 		<?php
 		$custom_create_functionality_modules = [];
-		$custom_create_functionality_modules = apply_filters('osdxp_dashboard_editor_create_functionality', $custom_create_functionality_modules);
+		$custom_create_functionality_modules = apply_filters(
+			'osdxp_dashboard_editor_create_functionality',
+			$custom_create_functionality_modules
+		);
 
 		foreach ($custom_create_functionality_modules as $custom_module) {
 			?>
@@ -72,7 +75,9 @@
 							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
 							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
 						</div>
-						<div class="button button-primary"><?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?></div>
+						<div class="button button-primary">
+							<?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?>
+						</div>
 					</div>
 				</div>
 			</a>
@@ -141,7 +146,10 @@
 
 		<?php
 		$custom_manage_functionality_modules = [];
-		$custom_manage_functionality_modules = apply_filters('osdxp_dashboard_editor_manage_functionality', $custom_manage_functionality_modules);
+		$custom_manage_functionality_modules = apply_filters(
+			'osdxp_dashboard_editor_manage_functionality',
+			$custom_manage_functionality_modules
+		);
 
 		foreach ($custom_manage_functionality_modules as $custom_module) {
 			?>

--- a/templates/dashboard-actions-editor.php
+++ b/templates/dashboard-actions-editor.php
@@ -41,23 +41,6 @@
 			</a>
 		<?php endif; ?>
 
-		<?php if ((current_user_can('publish_pages') || current_user_can('publish_posts')) && class_exists('CFConditionalContent')) : // phpcs:ignore?>
-			<a href="<?php echo admin_url('post-new.php?post_type=cf_cc_condition'); // phpcs:ignore?>" class="col">
-				<div class="postbox">
-					<div>
-						<div class="group">
-							<div class="dashicons-before dashicons-admin-post"></div>
-							<span><?php esc_html_e('Conditional Content', 'osdxp-dashboard'); ?></span>
-							<p><?php esc_html_e('Add New Condition', 'osdxp-dashboard'); ?></p>
-						</div>
-						<div class="button button-primary">
-							<?php esc_html_e('New Condition', 'osdxp-dashboard'); ?>
-						</div>
-					</div>
-				</div>
-			</a>
-		<?php endif; ?>
-
 		<?php
 		$custom_create_functionality_modules = [];
 		$custom_create_functionality_modules = apply_filters(
@@ -72,11 +55,11 @@
 					<div>
 						<div class="group">
 							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
-							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
-							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+							<span><?php echo esc_html($custom_module['title']); ?></span>
+							<p><?php echo esc_html($custom_module['subtitle']); ?></p>
 						</div>
 						<div class="button button-primary">
-							<?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?>
+							<?php echo esc_html($custom_module['button_text']); ?>
 						</div>
 					</div>
 				</div>
@@ -116,20 +99,6 @@
 			</a>
 		<?php endif; ?>
 
-		<?php if ((current_user_can('publish_pages') || current_user_can('publish_posts')) && class_exists('CFConditionalContent')) :  // phpcs:ignore?>
-			<a href="<?php echo admin_url('admin.php?page=cf-conditional-content-settings');  // phpcs:ignore?>" class="col">
-				<div class="postbox">
-					<div>
-						<div class="group">
-							<div class="dashicons-before dashicons-admin-post"></div>
-							<span><?php esc_html_e('Conditional Content', 'osdxp-dashboard'); ?></span>
-							<p><?php esc_html_e('Manage Conditions', 'osdxp-dashboard'); ?></p>
-						</div>
-					</div>
-				</div>
-			</a>
-		<?php endif; ?>
-
 		<?php if (current_user_can('upload_files')) : ?>
 			<a href="<?php echo admin_url('upload.php');  // phpcs:ignore?>" class="col">
 				<div class="postbox">
@@ -158,8 +127,8 @@
 					<div>
 						<div class="group">
 							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
-							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
-							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+							<span><?php echo esc_html($custom_module['title']); ?></span>
+							<p><?php echo esc_html($custom_module['subtitle']); ?></p>
 						</div>
 					</div>
 				</div>

--- a/templates/dashboard-actions-multisite-admin.php
+++ b/templates/dashboard-actions-multisite-admin.php
@@ -58,7 +58,10 @@
 
 		<?php
 		$custom_manage_functionality_modules = [];
-		$custom_manage_functionality_modules = apply_filters('osdxp_dashboard_multisite_manage_functionality', $custom_manage_functionality_modules);
+		$custom_manage_functionality_modules = apply_filters(
+			'osdxp_dashboard_multisite_manage_functionality',
+			$custom_manage_functionality_modules
+		);
 
 		foreach ($custom_manage_functionality_modules as $custom_module) {
 			?>
@@ -70,7 +73,9 @@
 							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
 							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
 						</div>
-						<div class="button button-primary"><?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?></div>
+						<div class="button button-primary">
+							<?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?>
+						</div>
 					</div>
 				</div>
 			</a>
@@ -126,7 +131,10 @@
 
 		<?php
 		$custom_create_functionality_modules = [];
-		$custom_create_functionality_modules = apply_filters('osdxp_dashboard_multisite_create_functionality', $custom_create_functionality_modules);
+		$custom_create_functionality_modules = apply_filters(
+			'osdxp_dashboard_multisite_create_functionality',
+			$custom_create_functionality_modules
+		);
 
 		foreach ($custom_create_functionality_modules as $custom_module) {
 			?>

--- a/templates/dashboard-actions-multisite-admin.php
+++ b/templates/dashboard-actions-multisite-admin.php
@@ -70,11 +70,11 @@
 					<div>
 						<div class="group">
 							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
-							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
-							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+							<span><?php echo esc_html($custom_module['title']); ?></span>
+							<p><?php echo esc_html($custom_module['subtitle']); ?></p>
 						</div>
 						<div class="button button-primary">
-							<?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?>
+							<?php echo esc_html($custom_module['button_text']); ?>
 						</div>
 					</div>
 				</div>
@@ -143,8 +143,8 @@
 					<div>
 						<div class="group">
 							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
-							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
-							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+							<span><?php echo esc_html($custom_module['title']); ?></span>
+							<p><?php echo esc_html($custom_module['subtitle']); ?></p>
 						</div>
 					</div>
 				</div>

--- a/templates/dashboard-actions-network-admin.php
+++ b/templates/dashboard-actions-network-admin.php
@@ -70,11 +70,11 @@
 					<div>
 						<div class="group">
 							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
-							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
-							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+							<span><?php echo esc_html($custom_module['title']); ?></span>
+							<p><?php echo esc_html($custom_module['subtitle']); ?></p>
 						</div>
 						<div class="button button-primary">
-							<?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?>
+							<?php echo esc_html($custom_module['button_text']); ?>
 						</div>
 					</div>
 				</div>
@@ -142,8 +142,8 @@
 					<div>
 						<div class="group">
 							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
-							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
-							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+							<span><?php echo esc_html($custom_module['title']); ?></span>
+							<p><?php echo esc_html($custom_module['subtitle']); ?></p>
 						</div>
 					</div>
 				</div>

--- a/templates/dashboard-actions-network-admin.php
+++ b/templates/dashboard-actions-network-admin.php
@@ -58,7 +58,10 @@
 
 		<?php
 		$custom_create_functionality_modules = [];
-		$custom_create_functionality_modules = apply_filters('osdxp_dashboard_network_create_functionality', $custom_create_functionality_modules);
+		$custom_create_functionality_modules = apply_filters(
+			'osdxp_dashboard_network_create_functionality',
+			$custom_create_functionality_modules
+		);
 
 		foreach ($custom_create_functionality_modules as $custom_module) {
 			?>
@@ -70,7 +73,9 @@
 							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
 							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
 						</div>
-						<div class="button button-primary"><?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?></div>
+						<div class="button button-primary">
+							<?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?>
+						</div>
 					</div>
 				</div>
 			</a>
@@ -125,7 +130,10 @@
 
 		<?php
 		$custom_manage_functionality_modules = [];
-		$custom_manage_functionality_modules = apply_filters('osdxp_dashboard_network_manage_functionality', $custom_manage_functionality_modules);
+		$custom_manage_functionality_modules = apply_filters(
+			'osdxp_dashboard_network_manage_functionality',
+			$custom_manage_functionality_modules
+		);
 
 		foreach ($custom_manage_functionality_modules as $custom_module) {
 			?>

--- a/templates/dashboard-actions-single-admin.php
+++ b/templates/dashboard-actions-single-admin.php
@@ -70,11 +70,11 @@
 					<div>
 						<div class="group">
 							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
-							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
-							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+							<span><?php echo esc_html($custom_module['title']); ?></span>
+							<p><?php echo esc_html($custom_module['subtitle']); ?></p>
 						</div>
 						<div class="button button-primary">
-							<?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?>
+							<?php echo esc_html($custom_module['button_text']); ?>
 						</div>
 					</div>
 				</div>
@@ -156,8 +156,8 @@
 					<div>
 						<div class="group">
 							<div class="dashicons-before <?php echo esc_attr($custom_module['icon']); ?>"></div>
-							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
-							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
+							<span><?php echo esc_html($custom_module['title']); ?></span>
+							<p><?php echo esc_html($custom_module['subtitle']); ?></p>
 						</div>
 					</div>
 				</div>

--- a/templates/dashboard-actions-single-admin.php
+++ b/templates/dashboard-actions-single-admin.php
@@ -58,7 +58,10 @@
 
 		<?php
 		$custom_manage_functionality_modules = [];
-		$custom_manage_functionality_modules = apply_filters('osdxp_dashboard_single_manage_functionality', $custom_manage_functionality_modules);
+		$custom_manage_functionality_modules = apply_filters(
+			'osdxp_dashboard_single_manage_functionality',
+			$custom_manage_functionality_modules
+		);
 
 		foreach ($custom_manage_functionality_modules as $custom_module) {
 			?>
@@ -70,7 +73,9 @@
 							<span><?php esc_html_e($custom_module['title'], 'osdxp-dashboard'); ?></span>
 							<p><?php esc_html_e($custom_module['subtitle'], 'osdxp-dashboard'); ?></p>
 						</div>
-						<div class="button button-primary"><?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?></div>
+						<div class="button button-primary">
+							<?php esc_html_e($custom_module['button_text'], 'osdxp-dashboard'); ?>
+						</div>
 					</div>
 				</div>
 			</a>
@@ -139,7 +144,10 @@
 
 		<?php
 		$custom_create_functionality_modules = [];
-		$custom_create_functionality_modules = apply_filters('osdxp_dashboard_single_create_functionality', $custom_create_functionality_modules);
+		$custom_create_functionality_modules = apply_filters(
+			'osdxp_dashboard_single_create_functionality',
+			$custom_create_functionality_modules
+		);
 
 		foreach ($custom_create_functionality_modules as $custom_module) {
 			?>

--- a/templates/modules-list-available.php
+++ b/templates/modules-list-available.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace OSDXP_Dashboard;
 
 if (isset($_GET["refresh"]) && $_GET['refresh']) { // phpcs:ignore
 	delete_transient(OSDXP_DASHBOARD_AVAILABLE_MODULES_TRANSIENT);
-    $jsonData = $this->getModulesData();
-    $data =  $this->transformData($jsonData);
+	$jsonData = $this->getModulesData();
+	$data =  $this->transformData($jsonData);
 }
 ?>
 

--- a/templates/modules-list-installed.php
+++ b/templates/modules-list-installed.php
@@ -107,11 +107,11 @@ if ($action) {
 			}
 
 			if (isset($_GET['from']) && 'import' == $_GET['from']) {
-				wp_redirect(self_admin_url('import.php?import=' . str_replace('-importer', '', dirname($module)))); // overrides the ?error=true one above and redirects to the Imports page, stripping the -importer suffix
+				wp_redirect(self_admin_url('import.php?import=' . str_replace('-importer', '', dirname($module)))); // phpcs:ignore -- overrides the ?error=true one above and redirects to the Imports page, stripping the -importer suffix
 			} elseif (isset($_GET['from']) && 'press-this' == $_GET['from']) {
 				wp_redirect(self_admin_url('press-this.php'));
 			} else {
-				wp_redirect(self_admin_url("admin.php?page=dxp-modules-installed&activate=true&module_status=$status&paged=$page&s=$s")); // overrides the ?error=true one above
+				wp_redirect(self_admin_url("admin.php?page=dxp-modules-installed&activate=true&module_status=$status&paged=$page&s=$s")); // phpcs:ignore -- overrides the ?error=true one above
 			}
 			exit;
 
@@ -586,7 +586,8 @@ if (isset($_GET['error'])) :
 	?>
 	<div id="message" class="error"><p><?php echo esc_attr($errmsg); ?></p>
 	<?php
-	if (!isset($_GET['main'])
+	if (
+		!isset($_GET['main'])
 		&& !isset($_GET['charsout'])
 		&& wp_verify_nonce($_GET['_error_nonce'], 'module-activation-error_' . $module)
 	) {
@@ -675,7 +676,8 @@ if (strlen($s)) {
 <hr class="wp-header-end">
 
 <?php
-/**
+
+/*
  * Fires before the modules list table is rendered.
  *
  * This hook also fires before the modules list table is rendered in the Network Admin.


### PR DESCRIPTION
## [v1.1.0 (2019-12-05)](https://github.com/osDXP/osdxp-dashboard/compare/v1.0.3...1.1.0)

## **Added**
- Update repository meta files (e612a00, closes #52, #45 and #17)
## **Changed**
- Make plugin agnostic of integrations (bc72a83, c6779c5, closes #15)
- Register assets by default and only enqueue them conditionally (96dad4f, closes #47)
- Use SCRIPT_DEBUG instead of WP_DEBUG when deciding what type of assets to load (
240e884, closes #46)

---
### [PR to develop](https://github.com/osDXP/osdxp-dashboard/pull/59) | [PR to master](https://github.com/osDXP/osdxp-dashboard/pull/58)
 